### PR TITLE
Upgrade to VariableSet

### DIFF
--- a/examples/ure/contraposition/contraposition.scm
+++ b/examples/ure/contraposition/contraposition.scm
@@ -52,7 +52,7 @@
         (bky (Evaluation kp (List vB vY))))
 
   (BindLink
-   (VariableList
+   (VariableSet
      (TypedVariable
         vA
         (Type "ConceptNode"))

--- a/examples/ure/meta-rules/conditional-instantiation-meta-rule.scm
+++ b/examples/ure/meta-rules/conditional-instantiation-meta-rule.scm
@@ -28,7 +28,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define conditional-full-instantiation-meta-variables
-  (VariableList
+  (VariableSet
      (TypedVariable
         (Variable "$TyVs")
         (TypeChoice

--- a/examples/ure/no-exec-output/no-exec-output.scm
+++ b/examples/ure/no-exec-output/no-exec-output.scm
@@ -25,7 +25,7 @@
         (vX (Variable "$X"))
         (akx (Evaluation kp (List vA vX))))
   (BindLink
-   (VariableList
+   (VariableSet
      (TypedVariable
         vA
         (Type "ConceptNode"))

--- a/examples/ure/rules/crisp-deduction-rule.scm
+++ b/examples/ure/rules/crisp-deduction-rule.scm
@@ -11,7 +11,7 @@
 
 (define crisp-deduction-rule
     (BindLink
-        (VariableList
+        (VariableSet
             (VariableNode "$A")
             (VariableNode "$B")
             (VariableNode "$C")

--- a/examples/ure/rules/crisp-modus-ponens-rule.scm
+++ b/examples/ure/rules/crisp-modus-ponens-rule.scm
@@ -11,7 +11,7 @@
 
 (define crisp-modus-ponens-rule
     (BindLink
-        (VariableList
+        (VariableSet
             (TypedVariable
                 (VariableNode "$A")
                 (TypeNode "PredicateNode"))

--- a/examples/ure/rules/fuzzy-conjunction-introduction-rule.scm
+++ b/examples/ure/rules/fuzzy-conjunction-introduction-rule.scm
@@ -37,7 +37,7 @@
          (InheritanceT (Type "InheritanceLink"))
          (type (TypeChoice EvaluationT InheritanceT))
          (gen-typed-variable (lambda (x) (TypedVariable x type)))
-         (vardecl (VariableList (map gen-typed-variable variables)))
+         (vardecl (VariableSet (map gen-typed-variable variables)))
          (pattern (Present variables))
          (rewrite (ExecutionOutput
                     (GroundedSchema "scm: fuzzy-conjunction-introduction-formula")

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -466,7 +466,7 @@ Handle Unify::substitute_vardecl(const Handle& vardecl,
 
 	HandleSeq oset;
 
-	if (t == VARIABLE_LIST) {
+	if (t == VARIABLE_LIST or t == VARIABLE_SET) {
 		for (const Handle& h : vardecl->getOutgoingSet()) {
 			Handle nh = substitute_vardecl(h, var2val);
 			if (nh)

--- a/tests/ure/RuleUTest.cxxtest
+++ b/tests/ure/RuleUTest.cxxtest
@@ -149,7 +149,7 @@ void RuleUTest::test_unify_target_deduction_1()
 
 	Handle rule = rules.begin()->first.get_rule(),
 		// Expected up to an alpha conversion
-		vardecl = al(VARIABLE_LIST,
+		vardecl = al(VARIABLE_SET,
 		             al(TYPED_VARIABLE_LINK, X, CT),
 		             al(TYPED_VARIABLE_LINK, V, CT)),
 		XV = al(INHERITANCE_LINK, X, V),
@@ -189,7 +189,7 @@ void RuleUTest::test_unify_target_deduction_2()
 
 	Handle rule = rules.begin()->first.get_rule(),
 		// Expected up to an alpha conversion
-		vardecl = al(VARIABLE_LIST,
+		vardecl = al(VARIABLE_SET,
 		             al(TYPED_VARIABLE_LINK, X, CT),
 		             al(TYPED_VARIABLE_LINK, V, CT)),
 		XV = al(INHERITANCE_LINK, X, V),
@@ -482,7 +482,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 		             "  (VariableNode \"$Q-38ea0de8\")"
 		             ")");
 	Handle vardecl =
-		_eval.eval_h("(VariableList"
+		_eval.eval_h("(VariableSet"
 		             "  (VariableNode \"$B-2db76aad\")"
 		             "  (TypedVariableLink"
 		             "    (VariableNode \"$Q-38ea0de8\")"
@@ -502,7 +502,7 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 	// Expected up to an alpha conversion
 	Handle expected =
 		_eval.eval_h("(BindLink"
-		             "  (VariableList"
+		             "  (VariableSet"
 		             "    (TypedVariableLink"
 		             "      (VariableNode \"$TyVs-6c74a409\")"
 		             "      (TypeChoice"
@@ -531,10 +531,10 @@ void RuleUTest::test_unify_target_implication_scope_to_implication_4()
 		             "        (Unquote (VariableNode \"$Q-7005b724\")))))))");
 
 	std::cout << "implication_scope_to_implication_rule = "
-	          << oc_to_string(implication_scope_to_implication_rule);
-	std::cout << "target = " << oc_to_string(target);
-	std::cout << "rule = " << oc_to_string(rule);
-	std::cout << "expected = " << oc_to_string(expected);
+	          << oc_to_string(implication_scope_to_implication_rule) << std::endl;
+	std::cout << "target = " << oc_to_string(target) << std::endl;
+	std::cout << "rule = " << oc_to_string(rule) << std::endl;
+	std::cout << "expected = " << oc_to_string(expected) << std::endl;
 
 	ScopeLinkPtr expected_sc = ScopeLinkCast(expected);
 
@@ -719,7 +719,7 @@ void RuleUTest::test_unify_target_closed_lambda_introduction_1()
 	Handle rule = rules.begin()->first.get_rule();
 	Handle expected =
 		_eval.eval_h("(BindLink"
-		             "  (VariableList"
+		             "  (VariableSet"
 		             "  )"
 		             "  (AndLink"
 		             "    (EvaluationLink"
@@ -802,7 +802,7 @@ void RuleUTest::test_unify_target_closed_lambda_introduction_2()
 	Handle rule = rules.begin()->first.get_rule();
 	Handle expected =
 		_eval.eval_h("(BindLink"
-		             "  (VariableList)"
+		             "  (VariableSet)"
 		             "  (AndLink"
 		             "    (EvaluationLink"
 		             "      (GroundedPredicateNode \"scm: closed-lambda-introduction-precondition\")"

--- a/tests/ure/backwardchainer/BITUTest.cxxtest
+++ b/tests/ure/backwardchainer/BITUTest.cxxtest
@@ -165,7 +165,7 @@ void BITUTest::test_expand_1()
 	AndBIT result = andbit.expand(leaf, rule, 1);
 	AndBIT expected(
 		_eval.eval_h("(BindLink"
-		             "  (VariableList"
+		             "  (VariableSet"
 		             "  )"
 		             "  (AndLink"
 		             "    (PresentLink"
@@ -422,7 +422,7 @@ void BITUTest::test_expand_2()
 	                           "  (VariableNode \"$B-edaffcb\")"
 	                           ")");
 	Handle vardecl =
-		_eval.eval_h("(VariableList"
+		_eval.eval_h("(VariableSet"
 		             "  (TypedVariableLink"
 		             "    (VariableNode \"$B-732fec2a\")"
 		             "    (TypeChoice"
@@ -463,7 +463,7 @@ void BITUTest::test_expand_2()
 	AndBIT result = andbit.expand(leaf, rule);
 	AndBIT expected(
 		_eval.eval_h("(BindLink"
-		             "  (VariableList"
+		             "  (VariableSet"
 		             "    (TypedVariableLink"
 		             "      (VariableNode \"$B-732fec2a\")"
 		             "      (TypeChoice"
@@ -479,6 +479,7 @@ void BITUTest::test_expand_2()
 		             "      (TypeChoice"
 		             "        (TypeNode \"TypedVariableLink\")"
 		             "        (TypeNode \"VariableNode\")"
+		             "        (TypeNode \"VariableSet\")"
 		             "        (TypeNode \"VariableList\")"
 		             "      )"
 		             "    )"
@@ -879,7 +880,7 @@ void BITUTest::test_expand_3()
 	                           "    (ConceptNode \"texts\")"
 	                           "    (NumberNode \"2.000000\")))");
 	Handle vardecl =
-		_eval.eval_h("(VariableList"
+		_eval.eval_h("(VariableSet"
 		             "  (TypedVariableLink"
 		             "    (VariableNode \"$g-2101505b\")"
 		             "    (TypeChoice"
@@ -899,7 +900,7 @@ void BITUTest::test_expand_3()
 	AndBIT result = andbit.expand(leaf, rule);
 	AndBIT expected(
 		_eval.eval_h("(BindLink"
-		             "  (VariableList"
+		             "  (VariableSet"
 		             "    (TypedVariableLink"
 		             "      (VariableNode \"$f-53364b8c\")"
 		             "      (TypeChoice"

--- a/tests/ure/backwardchainer/BackwardChainerUTest.cxxtest
+++ b/tests/ure/backwardchainer/BackwardChainerUTest.cxxtest
@@ -403,7 +403,7 @@ void BackwardChainerUTest::test_conditional_instantiation_tv_query()
 // thus having the type itself be a variable, like
 //
 // BindLink
-//   VariableList
+//   VariableSet
 //     TypedVariable
 //       Variable "$XVar"
 //       Type "VariableNode"

--- a/tests/ure/backwardchainer/scm/no-exec-output.scm
+++ b/tests/ure/backwardchainer/scm/no-exec-output.scm
@@ -25,7 +25,7 @@
         (vX (Variable "$X"))
         (akx (Evaluation kp (List vA vX))))
   (BindLink
-   (VariableList
+   (VariableSet
      (TypedVariable
         vA
         (Type "ConceptNode"))

--- a/tests/ure/forwardchainer/scm/dfc-tests.scm
+++ b/tests/ure/forwardchainer/scm/dfc-tests.scm
@@ -1,7 +1,7 @@
 ; Substitution case where $A = Cat and $B = Animal
 (define deduction-ab-substitute-1
     (BindLink
-        (VariableList
+        (VariableSet
             (TypedVariableLink
                 (VariableNode "$C")
                 (TypeNode "ConceptNode")))
@@ -34,7 +34,7 @@
 ; Substitution case where $B = Cat and $C = Animal
 (define deduction-ab-substitute-2
     (BindLink
-        (VariableList
+        (VariableSet
             (TypedVariableLink
                 (VariableNode "$A")
                 (TypeNode "ConceptNode")))

--- a/tests/ure/forwardchainer/scm/fc-unsatisfied-premise.scm
+++ b/tests/ure/forwardchainer/scm/fc-unsatisfied-premise.scm
@@ -3,7 +3,7 @@
 (define rule
  (BindLink
 
-  (VariableList
+  (VariableSet
    (TypedVariable (Variable "$a") (Type "ConceptNode"))
    (TypedVariable (Variable "$b") (Type "ConceptNode")))
 

--- a/tests/ure/forwardchainer/scm/negation-conflict.scm
+++ b/tests/ure/forwardchainer/scm/negation-conflict.scm
@@ -51,7 +51,7 @@
           (bky (Evaluation kp (List vB vY)))
        )
   (BindLink
-   (VariableList
+   (VariableSet
      (TypedVariable
         vA
         (Type "ConceptNode"))

--- a/tests/ure/meta-rules/conditional-full-instantiation-meta-rule.scm
+++ b/tests/ure/meta-rules/conditional-full-instantiation-meta-rule.scm
@@ -28,11 +28,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define conditional-full-instantiation-meta-variables
-  (VariableList
+  (VariableSet
      (TypedVariable
         (Variable "$TyVs")
         (TypeChoice
            (Type "TypedVariableLink")
+           (Type "VariableSet")
            (Type "VariableList")))
      (Variable "$P")
      (Variable "$Q")))

--- a/tests/ure/meta-rules/conditional-partial-instantiation-meta-rule.scm
+++ b/tests/ure/meta-rules/conditional-partial-instantiation-meta-rule.scm
@@ -48,13 +48,14 @@
          (P (Variable "$P"))
          (Q (Variable "$Q"))
          ;; Meta rule variable declaration
-         (meta-vardecl (VariableList
+         (meta-vardecl (VariableSet
                          TypedV1 TypedV2 TypedV3
                          TypedV1Type TypedV2Type TypedV3Type
                          P Q))
          ;; Meta rule main clause
          (implication (Quote
                         (ImplicationScope
+                          ;; Support VariableSet
                           (Unquote (VariableList
                             (TypedVariable V1 V1Type)
                             (TypedVariable V2 V2Type)
@@ -69,7 +70,7 @@
          (meta-pattern (And implication meta-precondition))
          ;; Produced rule variable declaration. V2 and V3 are to be
          ;; substituted.
-         (produced-vardecl (VariableList
+         (produced-vardecl (VariableSet
                              (TypedVariable V2 V2Type)
                              (TypedVariable V3 V3Type)))
          ;; Produced rule pattern. Just look for groundings of V2 and V3

--- a/tests/ure/rules/bc-deduction-rule.scm
+++ b/tests/ure/rules/bc-deduction-rule.scm
@@ -15,7 +15,7 @@
          (BC (Inheritance B C))
          (AC (Inheritance A C))
          (Concept (Type "ConceptNode"))
-         (vardecl (VariableList
+         (vardecl (VariableSet
                      (TypedVariable A Concept)
                      (TypedVariable B Concept)
                      (TypedVariable C Concept)))

--- a/tests/ure/rules/closed-lambda-introduction-rule.scm
+++ b/tests/ure/rules/closed-lambda-introduction-rule.scm
@@ -14,11 +14,12 @@
 ;; ----------------------------------------------------------------------
 
 (define closed-lambda-introduction-vardecl
-  (VariableList
+  (VariableSet
      (TypedVariableLink
         (VariableNode "$V")
         (TypeChoice
            (TypeNode "TypedVariableLink")
+           (TypeNode "VariableSet")
            (TypeNode "VariableList")
            (TypeNode "VariableNode")))
      (VariableNode "$B")))

--- a/tests/ure/rules/crisp-deduction-rule.scm
+++ b/tests/ure/rules/crisp-deduction-rule.scm
@@ -20,7 +20,7 @@
          (AB (link-type A B))
          (BC (link-type B C))
          (AC (link-type A C))
-         (vardecl (VariableList A B C))
+         (vardecl (VariableSet A B C))
          (precon1 (Evaluation (GroundedPredicate "scm: true-enough") AB))
          (precon2 (Evaluation (GroundedPredicate "scm: true-enough") BC))
          (precon3 (Not (Identical A C)))

--- a/tests/ure/rules/crisp-modus-ponens-rule.scm
+++ b/tests/ure/rules/crisp-modus-ponens-rule.scm
@@ -15,7 +15,7 @@
          (AB (Implication A B))
          (LambdaT (Type "LambdaLink"))
          (PredicateT (Type "PredicateNode"))
-         (vardecl (VariableList
+         (vardecl (VariableSet
                      (TypedVariable A (TypeChoice LambdaT PredicateT))
                      (TypedVariable B (TypeChoice LambdaT PredicateT))))
          (precon1 (Evaluation (GroundedPredicate "scm: true-enough") A))

--- a/tests/ure/rules/fc-deduction-rule.scm
+++ b/tests/ure/rules/fc-deduction-rule.scm
@@ -11,7 +11,7 @@
 
 (define fc-deduction-rule
     (BindLink
-        (VariableList
+        (VariableSet
             (TypedVariableLink
                 (VariableNode "$A")
                 (TypeNode "ConceptNode"))

--- a/tests/ure/rules/fuzzy-conjunction-introduction-rule.scm
+++ b/tests/ure/rules/fuzzy-conjunction-introduction-rule.scm
@@ -36,7 +36,7 @@
          (InheritanceT (Type "InheritanceLink"))
          (type (TypeChoice EvaluationT InheritanceT))
          (gen-typed-variable (lambda (x) (TypedVariable x type)))
-         (vardecl (VariableList (map gen-typed-variable variables)))
+         (vardecl (VariableSet (map gen-typed-variable variables)))
          (pattern (Present variables))
          (rewrite (ExecutionOutput
                     (GroundedSchema "scm: fuzzy-conjunction-introduction-formula")

--- a/tests/ure/rules/implication-and-lambda-factorization-rule.scm
+++ b/tests/ure/rules/implication-and-lambda-factorization-rule.scm
@@ -45,12 +45,13 @@
 ;; -----------------------------------------------------------------------
 
 (define implication-and-lambda-factorization-vardecl
-  (VariableList
+  (VariableSet
      (TypedVariableLink
         (VariableNode "$TyVs")
         (TypeChoice
            (TypeNode "TypedVariableLink")
            (TypeNode "VariableNode")
+           (TypeNode "VariableSet")
            (TypeNode "VariableList")))
      ;; We intensionally restrict $A1 and $A2 to be EvaluationLink to
      ;; ensure that we don't produce indefinitely nested AndLinks

--- a/tests/ure/rules/implication-instantiation-rule.scm
+++ b/tests/ure/rules/implication-instantiation-rule.scm
@@ -30,11 +30,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;
 
 (define implication-full-instantiation-variables
-  (VariableList
+  (VariableSet
      (TypedVariableLink
         (VariableNode "$TyVs")
         (TypeChoice
            (TypeNode "TypedVariableLink")
+           (TypeNode "VariableSet")))
            (TypeNode "VariableList")))
      (VariableNode "$P")
      (VariableNode "$Q")))
@@ -104,9 +105,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define implication-partial-instantiation-variables
-  (VariableList
+  (VariableSet
      (TypedVariableLink
         (VariableNode "$TyVs")
+        (TypeNode "VariableSet")
         (TypeNode "VariableList"))
      (VariableNode "$P")
      (VariableNode "$Q")))
@@ -158,7 +160,8 @@
                                         ; variable
          (TyV (list-ref TyVs-outgoings rnd-index))
                                         ; Build a VariableList of the
-                                        ; remaining variables
+                                        ; remaining variables. TODO:
+                                        ; support VariableSet as well.
          (TyVs-remain-list (rm-list-ref TyVs-outgoings rnd-index))
          (TyVs-remain-len (length TyVs-remain-list))
          (TyVs-remain (apply cog-new-link 'VariableList TyVs-remain-list)))

--- a/tests/ure/rules/implication-introduction-rule.scm
+++ b/tests/ure/rules/implication-introduction-rule.scm
@@ -18,7 +18,7 @@
 ;; ----------------------------------------------------------------------
 
 (define implication-introduction-variables
-  (VariableList
+  (VariableSet
      (TypedVariableLink
         (VariableNode "$P")
         (TypeChoice

--- a/tests/ure/rules/implication-scope-direct-evaluation-rule.scm
+++ b/tests/ure/rules/implication-scope-direct-evaluation-rule.scm
@@ -55,7 +55,7 @@
 ;; and retrieve all the other instances in the rule formula
 
 (define implication-scope-direct-evaluation-vardecl
-  (VariableList
+  (VariableSet
      (TypedVariable
         (Variable "$P")
         (Type "PredicateNode"))

--- a/tests/ure/rules/implication-scope-to-implication-rule.scm
+++ b/tests/ure/rules/implication-scope-to-implication-rule.scm
@@ -19,11 +19,12 @@
 ;; -----------------------------------------------------------------------
 
 (define implication-scope-to-implication-variables
-  (VariableList
+  (VariableSet
      (TypedVariableLink
         (VariableNode "$TyVs")
         (TypeChoice
            (TypeNode "TypedVariableLink")
+           ;; TODO: support VariableSet
            (TypeNode "VariableList")))
      (VariableNode "$P")
      (VariableNode "$Q")))

--- a/tests/ure/rules/pln-implication-and-lambda-factorization-rule.scm
+++ b/tests/ure/rules/pln-implication-and-lambda-factorization-rule.scm
@@ -45,18 +45,20 @@
 ;; -----------------------------------------------------------------------
 
 (define implication-and-lambda-factorization-variables
-  (VariableList
+  (VariableSet
      (TypedVariableLink
         (VariableNode "$TyVs-one")
         (TypeChoice
            (TypeNode "TypedVariableLink")
            (TypeNode "VariableNode")
+           (TypeNode "VariableSet")
            (TypeNode "VariableList")))
      (TypedVariableLink
         (VariableNode "$TyVs-two")
         (TypeChoice
            (TypeNode "TypedVariableLink")
            (TypeNode "VariableNode")
+           (TypeNode "VariableSet")
            (TypeNode "VariableList")))
      (VariableNode "$A1")
      (VariableNode "$A2")))

--- a/tests/ure/rules/unary-specialization-rule.scm
+++ b/tests/ure/rules/unary-specialization-rule.scm
@@ -1,6 +1,6 @@
 (define unary-specialization-rule
 (BindLink
-  (VariableList
+  (VariableSet
     (TypedVariableLink
       (VariableNode "$g")
       (TypeChoice


### PR DESCRIPTION
Use `VariableSet` instead of `VariableList` in unit tests and examples.

Performance improvement is significant. Space search cut goes from 6% (with previously existing redundancy detection mechanism) to 11% in average across all unit tests.