### PR TITLE
Make all copying explicit

### DIFF
--- a/opencog/ure/UREConfig.cc
+++ b/opencog/ure/UREConfig.cc
@@ -216,7 +216,8 @@ HandleSeq UREConfig::fetch_execution_outputs(const Handle& schema,
 {
 	// Retrieve rules
 	Handle var_node = _as.add_node(VARIABLE_NODE, "__EXECUTION_OUTPUT_VAR__"),
-		type_node = _as.add_node(TYPE_NODE, nameserver().getTypeName(type)),
+		type_node = _as.add_node(TYPE_NODE,
+		                std::move(std::string(nameserver().getTypeName(type)))),
 		typed_var = _as.add_link(TYPED_VARIABLE_LINK, var_node, type_node),
 		gl = _as.add_link(GET_LINK,
 		                  // TypedVariableLink
@@ -246,7 +247,8 @@ double UREConfig::fetch_num_param(const string& schema_name,
                                   const Handle& input,
                                   double default_value)
 {
-	Handle param_schema = _as.add_node(SCHEMA_NODE, schema_name);
+	Handle param_schema = _as.add_node(SCHEMA_NODE,
+	                             std::move(std::string(schema_name)));
 	HandleSeq outputs = fetch_execution_outputs(param_schema, input, NUMBER_NODE);
 
 	if (outputs.size() == 0) {
@@ -278,7 +280,8 @@ bool UREConfig::fetch_bool_param(const string& pred_name,
                                  bool default_value)
 {
 	string input_name = input->get_name();
-	Handle pred = _as.get_node(PREDICATE_NODE, pred_name);
+	Handle pred = _as.get_node(PREDICATE_NODE,
+	                           std::move(std::string(pred_name)));
 	if (pred) {
 		Handle eval = _as.get_link(EVALUATION_LINK, pred, input);
 		if (eval) {

--- a/opencog/ure/backwardchainer/BIT.cc
+++ b/opencog/ure/backwardchainer/BIT.cc
@@ -101,7 +101,7 @@ AndBIT::AndBIT(AtomSpace& bit_as, const Handle& target, Handle vardecl,
 	vardecl = filter_vardecl(vardecl, body); // remove useless vardecl
 	if (vardecl)
 		bl.insert(bl.begin(), vardecl);
-	fcs = bit_as.add_link(BIND_LINK, bl);
+	fcs = bit_as.add_link(BIND_LINK, std::move(bl));
 
 	// Insert the initial BITNode and initialize the AndBIT complexity
 	auto it = insert_bitnode(target, fitness);
@@ -342,7 +342,7 @@ Handle AndBIT::expand_fcs(const Handle& leaf,
 	HandleSeq noutgoings({npattern, nrewrite});
 	if (nvardecl)
 		noutgoings.insert(noutgoings.begin(), nvardecl);
-	nfcs = fcs->getAtomSpace()->add_link(BIND_LINK, noutgoings);
+	nfcs = fcs->getAtomSpace()->add_link(BIND_LINK, std::move(noutgoings));
 
 	// Log expansion
 	LAZY_URE_LOG_DEBUG << "Expanded forward chainer strategy:" << std::endl
@@ -486,7 +486,7 @@ Handle AndBIT::expand_fcs_rewrite(const Handle& fcs_rewrite,
 			HandleSeq args = arg->getOutgoingSet();
 			for (size_t i = 1; i < args.size(); i++)
 				args[i] = expand_fcs_rewrite(args[i], rule);
-			arg = as.add_link(LIST_LINK, args);
+			arg = as.add_link(LIST_LINK, std::move(args));
 		}
 		return as.add_link(EXECUTION_OUTPUT_LINK, {gsn, arg});
 	} else if (t == SET_LINK) {
@@ -495,7 +495,7 @@ Handle AndBIT::expand_fcs_rewrite(const Handle& fcs_rewrite,
 		HandleSeq args = fcs_rewrite->getOutgoingSet();
 		for (size_t i = 0; i < args.size(); i++)
 			args[i] = expand_fcs_rewrite(args[i], rule);
-		return as.add_link(SET_LINK, args);
+		return as.add_link(SET_LINK, std::move(args));
 	} else
 		// If none of the conditions apply just leave alone. Indeed,
 		// assuming that the pattern matcher is executing the rewrite
@@ -542,10 +542,10 @@ Handle AndBIT::mk_pattern(HandleSeq prs_clauses, HandleSeq virt_clauses) const
 	// Assemble the body
 	AtomSpace& as = *fcs->getAtomSpace();
 	if (not prs_clauses.empty())
-		virt_clauses.push_back(as.add_link(PRESENT_LINK, prs_clauses));
+		virt_clauses.push_back(as.add_link(PRESENT_LINK, std::move(prs_clauses)));
 	return virt_clauses.empty() ? Handle::UNDEFINED
 		: (virt_clauses.size() == 1 ? virt_clauses.front()
-		   : as.add_link(AND_LINK, virt_clauses));
+		   : as.add_link(AND_LINK, std::move(virt_clauses)));
 }
 
 void AndBIT::remove_redundant(HandleSeq& hs)

--- a/opencog/ure/backwardchainer/BackwardChainer.cc
+++ b/opencog/ure/backwardchainer/BackwardChainer.cc
@@ -134,7 +134,7 @@ bool BackwardChainer::termination()
 Handle BackwardChainer::get_results() const
 {
 	HandleSeq results(_results.begin(), _results.end());
-	return _kb_as.add_link(SET_LINK, results);
+	return _kb_as.add_link(SET_LINK, std::move(results));
 }
 
 void BackwardChainer::expand_meta_rules()

--- a/opencog/ure/backwardchainer/ControlPolicy.cc
+++ b/opencog/ure/backwardchainer/ControlPolicy.cc
@@ -401,7 +401,8 @@ Handle ControlPolicy::mk_expand_exec(const Handle& input_andbit_var,
                                      const Handle& inf_rule,
                                      const Handle& output_andbit_var)
 {
-	Handle expand_schema = an(SCHEMA_NODE, TraceRecorder::expand_andbit_schema_name);
+	Handle expand_schema = an(SCHEMA_NODE,
+		std::move(std::string(TraceRecorder::expand_andbit_schema_name)));
 	return al(EXECUTION_LINK,
 	          expand_schema,
 	          al(LIST_LINK,
@@ -413,7 +414,8 @@ Handle ControlPolicy::mk_expand_exec(const Handle& input_andbit_var,
 
 Handle ControlPolicy::mk_preproof_eval(const Handle& preproof_args_var)
 {
-	Handle preproof_pred = an(PREDICATE_NODE, preproof_predicate_name);
+	Handle preproof_pred = an(PREDICATE_NODE,
+	                          std::move(std::string(preproof_predicate_name)));
 	return al(EVALUATION_LINK,
 	          preproof_pred,
 	          al(UNQUOTE_LINK, preproof_args_var));
@@ -449,7 +451,7 @@ Handle ControlPolicy::mk_expansion_control_rules_query(const Handle& inf_rule,
 	Handle pat_expand_preproof_impl = al(QUOTE_LINK,
 	                                     al(IMPLICATION_SCOPE_LINK,
 	                                        al(UNQUOTE_LINK, vardecl_var),
-	                                        al(AND_LINK, antecedents),
+	                                        al(AND_LINK, std::move(antecedents)),
 	                                        out_preproof_eval));
 
 	// Bind of ImplicationScope with a pattern in its antecedent
@@ -463,7 +465,7 @@ Handle ControlPolicy::mk_expansion_control_rules_query(const Handle& inf_rule,
 	vardecls.insert(vardecls.end(), pattern_vars.begin(), pattern_vars.end());
 
 	Handle pat_expand_preproof_impl_bl = al(BIND_LINK,
-	                                        al(VARIABLE_LIST, vardecls),
+	                                        al(VARIABLE_LIST, std::move(vardecls)),
 	                                        pat_expand_preproof_impl,
 	                                        pat_expand_preproof_impl);
 
@@ -481,7 +483,7 @@ HandleSeq ControlPolicy::mk_pattern_vars(int n)
 Handle ControlPolicy::mk_pattern_var(int i)
 {
 	std::string name = std::string("$pattern-") + std::to_string(i);
-	return an(VARIABLE_NODE, name);
+	return an(VARIABLE_NODE, std::move(name));
 }
 
 double ControlPolicy::get_actual_mean(TruthValuePtr tv) const

--- a/opencog/ure/backwardchainer/TraceRecorder.cc
+++ b/opencog/ure/backwardchainer/TraceRecorder.cc
@@ -34,13 +34,13 @@ const std::string TraceRecorder::proof_predicate_name = "URE:BC:proof-of";
 TraceRecorder::TraceRecorder(AtomSpace* tr_as) : _trace_as(tr_as) {
 	if (_trace_as) {
 		_target_predicate =
-			_trace_as->add_node(PREDICATE_NODE, target_predicate_name);
+			_trace_as->add_node(PREDICATE_NODE, std::move(std::string(target_predicate_name)));
 		_andbit_predicate =
-			_trace_as->add_node(PREDICATE_NODE, andbit_predicate_name);
+			_trace_as->add_node(PREDICATE_NODE, std::move(std::string(andbit_predicate_name)));
 		_expand_andbit_schema =
-			_trace_as->add_node(SCHEMA_NODE, expand_andbit_schema_name);
+			_trace_as->add_node(SCHEMA_NODE, std::move(std::string(expand_andbit_schema_name)));
 		_proof_predicate =
-			_trace_as->add_node(PREDICATE_NODE, proof_predicate_name);
+			_trace_as->add_node(PREDICATE_NODE, std::move(std::string(proof_predicate_name)));
 	}
 }
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -241,7 +241,7 @@ Handle ForwardChainer::get_results() const
 {
 	HandleSet rs = get_results_set();
 	HandleSeq results(rs.begin(), rs.end());
-	return _kb_as.add_link(SET_LINK, results);
+	return _kb_as.add_link(SET_LINK, std::move(results));
 }
 
 HandleSet ForwardChainer::get_results_set() const

--- a/tests/ure/backwardchainer/BackwardChainerUTest.cxxtest
+++ b/tests/ure/backwardchainer/BackwardChainerUTest.cxxtest
@@ -120,7 +120,8 @@ void BackwardChainerUTest::reset_bc()
 
 	// std::cout << "eval_result = " << eval_result << std::endl;
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	_bc = new BackwardChainer(_as, top_rbs, Handle::UNDEFINED);
 }
@@ -193,7 +194,8 @@ void BackwardChainerUTest::test_deduction()
 	load_from_path("bc-transitive-closure.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 	Handle X = an(VARIABLE_NODE, "$X"),
 		D = an(CONCEPT_NODE, "D"),
 		target = al(INHERITANCE_LINK, X, D);
@@ -225,7 +227,8 @@ void BackwardChainerUTest::test_deduction_tv_query()
 	load_from_path("bc-transitive-closure.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 	Handle target = _eval.eval_h("(Inheritance"
 	                             "   (Concept \"A\")"
 	                             "   (Concept \"D\"))");
@@ -246,7 +249,8 @@ void BackwardChainerUTest::test_modus_ponens_tv_query()
 	load_from_path("modus-ponens-example.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 	Handle target = an(PREDICATE_NODE, "T");
 
 	BackwardChainer bc(_as, top_rbs, target);
@@ -266,7 +270,8 @@ void BackwardChainerUTest::test_conjunction_fuzzy_evaluation_tv_query()
 	result = load_from_path("simple-conjunction.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle P = an(PREDICATE_NODE, "P"),
 		Q = an(PREDICATE_NODE, "Q"),
@@ -295,7 +300,8 @@ void BackwardChainerUTest::test_conditional_instantiation_1()
 	result = load_from_path("friends.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle are_friends = an(PREDICATE_NODE, "are-friends"),
 		john = an(CONCEPT_NODE, "John"),
@@ -336,7 +342,8 @@ void BackwardChainerUTest::test_conditional_instantiation_2()
 	load_from_path("animals.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle green = an(CONCEPT_NODE, "green"),
 		Fritz = an(CONCEPT_NODE, "Fritz"),
@@ -366,7 +373,8 @@ void BackwardChainerUTest::test_conditional_instantiation_tv_query()
 	load_from_path("animals.scm");
 	randGen().seed(500);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle target =
 	    _eval.eval_h("(InheritanceLink"
@@ -429,7 +437,8 @@ void BackwardChainerUTest::test_conditional_partial_instantiation()
 	result = load_from_path("friends.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle target = _eval.eval_h("(ImplicationScope"
 	                             "   (TypedVariable"
@@ -477,7 +486,8 @@ void BackwardChainerUTest::test_impossible_criminal()
 	load_from_path("criminal.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle target =
 	    _eval.eval_h("(InheritanceLink"
@@ -512,7 +522,8 @@ void BackwardChainerUTest::test_criminal()
 	load_from_path("criminal.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle target_var = _eval.eval_h("(VariableNode \"$who\")");
 	Handle target =
@@ -642,7 +653,8 @@ void BackwardChainerUTest::xtest_green_balls()
 	load_from_path("green-balls-targets.scm");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle target = _eval.eval_h("target-known-evidence");
 
@@ -672,7 +684,8 @@ void BackwardChainerUTest::xtest_induction()
 
 	randGen().seed(500);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle target = _eval.eval_h("bc-induction-target");
 
@@ -695,7 +708,8 @@ void BackwardChainerUTest::xtest_focus_set()
 	load_from_path("animals.scm");
 	randGen().seed(500);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle green = an(CONCEPT_NODE, "green"),
 		Fritz = an(CONCEPT_NODE, "Fritz"),

--- a/tests/ure/forwardchainer/ForwardChainerUTest.cxxtest
+++ b/tests/ure/forwardchainer/ForwardChainerUTest.cxxtest
@@ -207,7 +207,8 @@ void ForwardChainerUTest::test_fritz_green()
 	_eval.eval("(load-from-path \"animals.scm\")");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle Fritz = an(CONCEPT_NODE, "Fritz"),
 		croaks = an(PREDICATE_NODE, "croaks"),
@@ -239,7 +240,8 @@ void ForwardChainerUTest::test_tweety_not_green()
 	_eval.eval("(load-from-path \"animals.scm\")");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle Tweety = an(CONCEPT_NODE, "Tweety"),
 		eats_flies = an(PREDICATE_NODE, "croaks"),
@@ -273,7 +275,8 @@ void ForwardChainerUTest::test_fritz_green_alt()
 	_eval.eval("(load-from-path \"animals.scm\")");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle Fritz = an(CONCEPT_NODE, "Fritz"),
 		croaks = an(PREDICATE_NODE, "croaks"),
@@ -306,7 +309,8 @@ void ForwardChainerUTest::test_tweety_not_green_alt()
 	_eval.eval("(load-from-path \"animals.scm\")");
 	randGen().seed(0);
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle Tweety = an(CONCEPT_NODE, "Tweety"),
 		eats_flies = an(PREDICATE_NODE, "eats_flies"),
@@ -371,7 +375,7 @@ void ForwardChainerUTest::test_negation_conflict()
 
 	HandleSet resultSet = fc.get_results_set();
 	HandleSeq resultHandleSeq(resultSet.begin(), resultSet.end());
-	Handle results = al(SET_LINK, resultHandleSeq);
+	Handle results = al(SET_LINK, std::move(resultHandleSeq));
 
 	Handle American = an(CONCEPT_NODE, "American"),
 	       German = an(CONCEPT_NODE, "German"),
@@ -395,7 +399,8 @@ void ForwardChainerUTest::test_bindlink_no_vardecl()
 
 	_eval.eval("(load-from-path \"fc-bindlink-no-vardecl-config.scm\")");
 
-	Handle top_rbs = _as.get_node(CONCEPT_NODE, UREConfig::top_rbs_name);
+	Handle top_rbs = _as.get_node(CONCEPT_NODE,
+	                     std::move(std::string(UREConfig::top_rbs_name)));
 
 	Handle source = al(MEMBER_LINK, an(CONCEPT_NODE, "terrier"),
 	                   an(CONCEPT_NODE, "dog"));


### PR DESCRIPTION
This will mostly avoid copies, by making the few that are actually needed explicit. 