### PR TITLE
There is no pattern matcher in here...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,12 +305,6 @@ IF (CXXTEST_FOUND)
 		COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS)
 		COMMENT "Running Guile and Python-bridge tests..."
 	)
-	ADD_CUSTOM_TARGET(test_query
-		DEPENDS tests/query
-		WORKING_DIRECTORY tests/query
-		COMMAND ${CMAKE_CTEST_COMMAND} $(ARGS)
-		COMMENT "Running pattern matcher tests..."
-	)
 ENDIF (CXXTEST_FOUND)
 
 IF (NOT WIN32)


### PR DESCRIPTION
Remove unused target. Well, also `test_scm` target is also unused .. but might be plausibly used in the future ..