### PR TITLE
Fix python import of bad TruthValue

### DIFF
--- a/tests/cython/forwardchainer/test_fc.py
+++ b/tests/cython/forwardchainer/test_fc.py
@@ -6,7 +6,6 @@ from opencog.ure import ForwardChainer
 from opencog.scheme_wrapper import load_scm, scheme_eval
 from opencog.type_constructors import *
 from opencog.utilities import initialize_opencog, finalize_opencog
-from opencog.atomspace import TruthValue
 
 
 class FCTest(TestCase):


### PR DESCRIPTION
This was causing a spurious unit test failure.