### PR TITLE
Complete source rule producer

### DIFF
--- a/examples/ure/simple/crisp-config.scm
+++ b/examples/ure/simple/crisp-config.scm
@@ -28,8 +28,4 @@
 (ure-add-rules crisp-rbs crisp-rules)
 
 ; Termination criteria parameters
-(ure-set-num-parameter crisp-rbs "URE:maximum-iterations" 20)
-
-; Attention allocation (set the TV strength to 0 to disable it, 1 to
-; enable it)
-(ure-set-fuzzy-bool-parameter crisp-rbs "URE:attention-allocation" 0)
+(ure-set-maximum-iterations crisp-rbs 20)

--- a/opencog/scm/opencog/ure/ure-utils.scm
+++ b/opencog/scm/opencog/ure/ure-utils.scm
@@ -24,6 +24,7 @@
 ;; -- ure-set-maximum-iterations -- Set the URE:maximum-iterations parameter
 ;; -- ure-set-complexity-penalty -- Set the URE:complexity-penalty parameter
 ;; -- ure-set-jobs -- Set the URE:jobs parameter
+;; -- ure-set-production-application-ratio -- Set the URE:production-application-ratio parameter
 ;; -- ure-set-fc-retry-exhausted-sources -- Set the URE:FC:retry-exhausted-sources parameter
 ;; -- ure-set-fc-full-rule-application -- Set the URE:FC:full-rule-application parameter
 ;; -- ure-set-bc-maximum-bit-size -- Set the URE:BC:maximum-bit-size
@@ -88,6 +89,7 @@
                  (maximum-iterations *unspecified*)
                  (complexity-penalty *unspecified*)
                  (jobs *unspecified*)
+                 (production-application-ratio *unspecified*)
                  (fc-retry-exhausted-sources *unspecified*)
                  (fc-full-rule-application *unspecified*))
 "
@@ -101,6 +103,7 @@
                  #:maximum-iterations mi
                  #:complexity-penalty cp
                  #:jobs jb
+                 #:production-application-ratio par
                  #:fc-retry-exhausted-sources res
                  #:fc-full-rule-application fra)
 
@@ -128,10 +131,13 @@
       Possible range is (-inf, +inf) but it's rarely necessary in practice
       to go outside of [-10, 10].
 
-  jb: [optional, default=1] Number of jobs to run in parallel. Can
-      speed up reasoning. Note that this may alter the results, especially
-      for the forward chainer as the output of a rule application may depend
-      on the output of other rules.
+  jb: [optional, default=1] Number of jobs to run in parallel.
+
+  par: [optional, default=1] This parameter controls how many tuples
+       -- (source, rule) for forward chainer or (inference, premise, rule)
+       for backward chainer -- are produced in average before an application
+       takes place. The higher the more tuples to choose from, which can lead
+       to better inference control.
 
   res: [optional, default=#f] Whether exhausted sources should be
        retried. A source is exhausted if all its valid rules (so that at
@@ -160,6 +166,8 @@
       (ure-set-complexity-penalty rbs complexity-penalty))
   (if (not (unspecified? jobs))
       (ure-set-jobs rbs jobs))
+  (if (not (unspecified? production-application-ratio))
+      (ure-set-production-application-ratio rbs production-application-ratio))
   (if (not (unspecified? fc-retry-exhausted-sources))
       (ure-set-fc-retry-exhausted-sources rbs fc-retry-exhausted-sources))
   (if (not (unspecified? fc-full-rule-application))
@@ -180,6 +188,7 @@
                  (maximum-iterations *unspecified*)
                  (complexity-penalty *unspecified*)
                  (jobs *unspecified*)
+                 (production-application-ratio *unspecified*)
                  (bc-maximum-bit-size *unspecified*)
                  (bc-mm-complexity-penalty *unspecified*)
                  (bc-mm-compressiveness *unspecified*))
@@ -194,6 +203,8 @@
                  #:attention-allocation aa
                  #:maximum-iterations mi
                  #:complexity-penalty cp
+                 #:jobs jb
+                 #:production-application-ratio par
                  #:bc-maximum-bit-size mbs
                  #:bc-mm-complexity-penalty mcp
                  #:bc-mm-compressiveness mc)
@@ -223,10 +234,13 @@
       depth.  Possible range is (-inf, +inf) but it's rarely necessary in
       practice to go outside of [-10, 10].
 
-  jb: [optional, default=1] Number of jobs to run in parallel. Can
-      speed up reasoning, note that this may alter the results, especially
-      for the forward chainer as the output of a rule application may depend
-      on the output of the other rules.
+  jb: [optional, default=1] Number of jobs to run in parallel.
+
+  par: [optional, default=1] This parameter controls how many tuples
+       -- (source, rule) for forward chainer or (inference, premise, rule)
+       for backward chainer -- are produced in average before an application
+       takes place. The higher the more tuples to choose from, which can lead
+       to better inference control.
 
   mbs: [optional, default=-1] Maximum size of the inference tree pool
        to evolve. Negative means unlimited.
@@ -254,6 +268,8 @@
       (ure-set-complexity-penalty rbs complexity-penalty))
   (if (not (unspecified? jobs))
       (ure-set-jobs rbs jobs))
+  (if (not (unspecified? production-application-ratio))
+      (ure-set-production-application-ratio rbs production-application-ratio))
   (if (not (unspecified? bc-maximum-bit-size))
       (ure-set-bc-maximum-bit-size rbs bc-maximum-bit-size))
   (if (not (unspecified? bc-mm-complexity-penalty))
@@ -646,6 +662,19 @@
   Delete any previous one if exists.
 "
   (ure-set-num-parameter rbs "URE:jobs" value))
+
+(define (ure-set-production-application-ratio rbs value)
+"
+  Set the URE:production-application-ratio parameter of a given RBS
+
+  ExecutionLink
+    SchemaNode \"URE:production-application-ratio\"
+    rbs
+    NumberNode value
+
+  Delete any previous one if exists.
+"
+  (ure-set-num-parameter rbs "URE:production-application-ratio" value))
 
 (define (ure-set-fc-retry-exhausted-sources rbs value)
 "
@@ -1094,6 +1123,7 @@
           ure-set-maximum-iterations
           ure-set-complexity-penalty
           ure-set-jobs
+          ure-set-production-application-ratio
           ure-set-fc-retry-exhausted-sources
           ure-set-fc-full-rule-application
           ure-set-bc-maximum-bit-size

--- a/opencog/ure/BetaDistribution.cc
+++ b/opencog/ure/BetaDistribution.cc
@@ -154,7 +154,12 @@ TruthValuePtr mk_stv(double mean, double variance,
 	if (alpha < 1 and beta < 1)
 		mode = mean;
 
-	LAZY_URE_LOG_FINE << "mk_stv alpha alpha = " << alpha
+	LAZY_URE_LOG_FINE << "mk_stv(mean=" << mean
+	                  << ", variance=" << variance
+	                  << ", prior_alpha=" << prior_alpha
+	                  << ", prior_beta=" << prior_beta
+	                  << ")" << std::endl
+	                  << "with alpha = " << alpha
 	                  << ", beta = " << beta << ", count = " << count
 	                  << ", confidence = " << confidence << ", mode = " << mode;
 

--- a/opencog/ure/CMakeLists.txt
+++ b/opencog/ure/CMakeLists.txt
@@ -10,6 +10,7 @@ ADD_LIBRARY(ure
 	forwardchainer/FCStat
 	forwardchainer/ForwardChainer
 	forwardchainer/SourceSet
+	forwardchainer/SourceRuleSet
 	URELogger
 	URESCM
 	Rule

--- a/opencog/ure/Rule.cc
+++ b/opencog/ure/Rule.cc
@@ -114,6 +114,20 @@ bool RuleSet::operator<(const RuleSet& other) const
 	return false;
 }
 
+RuleSet::iterator RuleSet::find(const RulePtr& rule)
+{
+	if (not boost::binary_search(*this, rule, rule_ptr_less()))
+		return end();
+	return boost::lower_bound(*this, rule, rule_ptr_less());
+}
+
+RuleSet::const_iterator RuleSet::find(const RulePtr& rule) const
+{
+	if (not boost::binary_search(*this, rule, rule_ptr_less()))
+		return cend();
+	return boost::lower_bound(*this, rule, rule_ptr_less());
+}
+
 std::string RuleSet::to_string(const std::string& indent) const
 {
 	std::stringstream ss;
@@ -231,6 +245,11 @@ bool Rule::operator==(const Rule& r) const
 	return content_eq(Handle(_rule), Handle(r._rule));
 }
 
+bool Rule::operator<(const Rule& r) const
+{
+	return content_based_handle_less()(Handle(_rule), Handle(r._rule));
+}
+
 Rule& Rule::operator=(const Rule& r)
 {
 	premises_as_clauses = r.premises_as_clauses;
@@ -242,16 +261,6 @@ Rule& Rule::operator=(const Rule& r)
 	_exhausted = r._exhausted;
 
 	return *this;
-}
-
-bool Rule::operator<(const Rule& r) const
-{
-	return content_based_handle_less()(Handle(_rule), Handle(r._rule));
-}
-
-bool Rule::is_alpha_equivalent(const Rule& r) const
-{
-	return _rule->is_equal(Handle(r._rule));
 }
 
 TruthValuePtr Rule::get_tv() const

--- a/opencog/ure/Rule.cc
+++ b/opencog/ure/Rule.cc
@@ -102,7 +102,7 @@ bool RuleSet::operator==(const RuleSet& other) const
 
 	size_t i = 0;
 	for (; i < size(); i++)
-		if (at(i) != other.at(i))
+		if (*at(i) != *other.at(i))
 			return false;
 	return true;
 }

--- a/opencog/ure/Rule.cc
+++ b/opencog/ure/Rule.cc
@@ -28,6 +28,8 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
+#include <boost/range/algorithm/binary_search.hpp>
+#include <boost/range/algorithm/lower_bound.hpp>
 
 #include <opencog/util/oc_assert.h>
 #include <opencog/atoms/base/Link.h>
@@ -86,11 +88,10 @@ HandleSet RuleSet::aliases() const
 
 std::pair<RuleSet::iterator, bool> RuleSet::insert(RulePtr rule)
 {
-	// NEXT: optimize for logarithmic time insertion
-	RuleSet::iterator it = begin();
-	for (; it != end(); ++it)
-		if (rule->is_alpha_equivalent(**it))
-			return {it, false};
+	if (boost::binary_search(*this, rule, rule_ptr_less()))
+		return {end(), false};
+
+	RuleSet::iterator it = boost::lower_bound(*this, rule, rule_ptr_less());
 	it = super::insert(it, rule);
 	return {it, true};
 }

--- a/opencog/ure/Rule.cc
+++ b/opencog/ure/Rule.cc
@@ -78,13 +78,15 @@ HandleSet RuleSet::aliases() const
 	return aliases;
 }
 
-bool RuleSet::insert(const Rule& rule)
+std::pair<RuleSet::iterator, bool> RuleSet::insert(const Rule& rule)
 {
-	for (const auto& r : *this)
-		if (rule.is_alpha_equivalent(r))
-			return false;
-	push_back(rule);
-	return true;
+	// TODO: optimize for logarithmic time insertion
+	RuleSet::iterator it = begin();
+	for (; it != end(); ++it)
+		if (rule.is_alpha_equivalent(*it))
+			return {it, false};
+	it = super::insert(it, rule);
+	return {it, true};
 }
 
 std::string RuleSet::to_string(const std::string& indent) const

--- a/opencog/ure/Rule.h
+++ b/opencog/ure/Rule.h
@@ -344,7 +344,7 @@ private:
 	// True if the rule has already been applied.
 	bool _exhausted;
 
-	// NEXT TODO: subdivide in smaller and shared mutexes
+	// TODO: subdivide in smaller and shared mutexes
 	mutable std::mutex _mutex;
 
 	// Return a copy of the rule with the variables alpha-converted

--- a/opencog/ure/Rule.h
+++ b/opencog/ure/Rule.h
@@ -76,13 +76,7 @@ public:
 	 *
 	 * Return a pair (iterator, true) iff rule has been successfully inserted.
 	 */
-	std::pair<RuleSet::iterator, bool> insert(RulePtr rule);
-
-	/**
-	 * Content based comparison.
-	 */
-	bool operator==(const RuleSet& other) const;
-	bool operator<(const RuleSet& other) const;
+	std::pair<iterator, bool> insert(RulePtr rule);
 
 	/**
 	 * Insert a range of rules
@@ -93,6 +87,18 @@ public:
 		for (; from != to; ++from)
 			insert(*from);
 	}
+
+	/**
+	 * Content based comparison.
+	 */
+	bool operator==(const RuleSet& other) const;
+	bool operator<(const RuleSet& other) const;
+
+	/**
+	 * Log-time search
+	 */
+	iterator find(const RulePtr& rule);
+	const_iterator find(const RulePtr& rule) const;
 
 	std::string to_string(const std::string& indent=empty_string) const;
 	std::string to_short_string(const std::string& indent=empty_string) const;
@@ -174,17 +180,12 @@ public:
 	 */
 	bool verify_rule();
 	
-	// Comparison
+	// Content-based (including alpha-equivalence) comparison
 	bool operator==(const Rule& r) const;
+	bool operator<(const Rule& r) const;
 
 	// Assignment
 	Rule& operator=(const Rule& r);
-
-	/**
-	 * Order by weight, or if equal by handle value.
-	 */
-	bool operator<(const Rule& r) const;
-	bool is_alpha_equivalent(const Rule&) const;
 
 	// Modifiers
 	void set_rule(const Handle&);

--- a/opencog/ure/Rule.h
+++ b/opencog/ure/Rule.h
@@ -46,6 +46,8 @@ class Rule;
  */
 class RuleSet : public std::vector<Rule>
 {
+	typedef std::vector<Rule> super;
+
 public:
 	/**
 	 * Run all meta rules over as and insert the resulting rules back

--- a/opencog/ure/Rule.h
+++ b/opencog/ure/Rule.h
@@ -63,9 +63,9 @@ public:
 	 * Insert rule in the rule set if no other alpha-equivalent rule is
 	 * in it.
 	 *
-	 * Return true iff rule has been successfully inserted.
+	 * Return a pair (iterator, true) iff rule has been successfully inserted.
 	 */
-	bool insert(const Rule& rule);
+	std::pair<RuleSet::iterator, bool> insert(const Rule& rule);
 
 	/**
 	 * Insert a range of rules

--- a/opencog/ure/Rule.h
+++ b/opencog/ure/Rule.h
@@ -245,7 +245,7 @@ public:
 	HandlePairSeq get_conclusions() const;
 
 	/**
-	 * Get the default TruthValue associated with the rule.
+	 * Get the TruthValue associated with the rule.
 	 */
 	TruthValuePtr get_tv() const;
 

--- a/opencog/ure/ThompsonSampling.cc
+++ b/opencog/ure/ThompsonSampling.cc
@@ -61,6 +61,7 @@ std::vector<double> ThompsonSampling::distribution()
 
 size_t ThompsonSampling::operator()()
 {
+	OC_ASSERT(not _tvs.empty());
 	std::vector<double> weights = distribution();
 	std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
 	return dist(randGen());

--- a/opencog/ure/ThompsonSampling.h
+++ b/opencog/ure/ThompsonSampling.h
@@ -49,7 +49,7 @@ public:
 	 * @paran bins Number of bins to discretize the second order
 	 *             distributions associated to each TV.
 	 */
-	ThompsonSampling(const std::vector<TruthValuePtr>& tvs, unsigned bins=100);
+	ThompsonSampling(const TruthValueSeq& tvs, unsigned bins=100);
 
 	/**
 	 * Return the index distribution, a probability for each index to

--- a/opencog/ure/UREConfig.cc
+++ b/opencog/ure/UREConfig.cc
@@ -193,7 +193,7 @@ void UREConfig::fetch_common_parameters(const Handle& rbs)
 		          "Please check rules in /atomspace/examples/ure for example.\n\n",
 		          rule_name->to_short_string().c_str());
 
-		_common_params.rules.insert(Rule(rule_name, rbs));
+		_common_params.rules.insert(createRule(rule_name, rbs));
 	}
 
 	// Fetch maximum number of iterations

--- a/opencog/ure/UREConfig.cc
+++ b/opencog/ure/UREConfig.cc
@@ -33,14 +33,24 @@ using namespace opencog;
 const std::string UREConfig::top_rbs_name = "URE";
 
 // Parameters
-const std::string UREConfig::max_iter_name = "URE:maximum-iterations";
-const std::string UREConfig::complexity_penalty_name = "URE:complexity-penalty";
-const std::string UREConfig::jobs_name = "URE:jobs";
-const std::string UREConfig::fc_retry_exhausted_sources_name = "URE:FC:retry-exhausted-sources";
-const std::string UREConfig::fc_full_rule_application_name = "URE:FC:full-rule-application";
-const std::string UREConfig::bc_max_bit_size_name = "URE:BC:maximum-bit-size";
-const std::string UREConfig::bc_mm_complexity_penalty_name = "URE:BC:MM:complexity-penalty";
-const std::string UREConfig::bc_mm_compressiveness_name = "URE:BC:MM:compressiveness";
+const std::string UREConfig::max_iter_name =
+	"URE:maximum-iterations";
+const std::string UREConfig::complexity_penalty_name =
+	"URE:complexity-penalty";
+const std::string UREConfig::jobs_name =
+	"URE:jobs";
+const std::string UREConfig::production_application_ratio_name =
+	"URE:production-application-ratio";
+const std::string UREConfig::fc_retry_exhausted_sources_name =
+	"URE:FC:retry-exhausted-sources";
+const std::string UREConfig::fc_full_rule_application_name =
+	"URE:FC:full-rule-application";
+const std::string UREConfig::bc_max_bit_size_name =
+	"URE:BC:maximum-bit-size";
+const std::string UREConfig::bc_mm_complexity_penalty_name =
+	"URE:BC:MM:complexity-penalty";
+const std::string UREConfig::bc_mm_compressiveness_name =
+	"URE:BC:MM:compressiveness";
 
 UREConfig::UREConfig(AtomSpace& as, const Handle& rbs) : _as(as)
 {
@@ -76,6 +86,11 @@ double UREConfig::get_complexity_penalty() const
 int UREConfig::get_jobs() const
 {
 	return _common_params.jobs;
+}
+
+double UREConfig::get_production_application_ratio() const
+{
+	return _common_params.production_application_ratio;
 }
 
 bool UREConfig::get_retry_exhausted_sources() const
@@ -123,6 +138,11 @@ void UREConfig::set_complexity_penalty(double cp)
 void UREConfig::set_jobs(int j)
 {
 	_common_params.jobs = j;
+}
+
+void UREConfig::set_production_application_ratio(double par)
+{
+	_common_params.production_application_ratio = par;
 }
 
 void UREConfig::set_retry_exhausted_sources(bool rs)
@@ -185,6 +205,10 @@ void UREConfig::fetch_common_parameters(const Handle& rbs)
 
 	// Fetch number of jobs
 	_common_params.jobs = fetch_num_param(jobs_name, rbs, 1);
+
+	// Fetch production application ratio
+	_common_params.production_application_ratio =
+		fetch_num_param(production_application_ratio_name, rbs, 1);
 }
 
 void UREConfig::fetch_fc_parameters(const Handle& rbs)

--- a/opencog/ure/UREConfig.h
+++ b/opencog/ure/UREConfig.h
@@ -63,6 +63,7 @@ public:
 	int get_maximum_iterations() const;
 	double get_complexity_penalty() const;
 	int get_jobs() const;
+	double get_production_application_ratio() const;
 	// FC
 	bool get_retry_exhausted_sources() const;
 	bool get_full_rule_application() const;
@@ -83,6 +84,7 @@ public:
 	void set_maximum_iterations(int);
 	void set_complexity_penalty(double);
 	void set_jobs(int);
+	void set_production_application_ratio(double);
 	// FC
 	void set_retry_exhausted_sources(bool);
 	void set_full_rule_application(bool);
@@ -108,6 +110,9 @@ public:
 
 	// Name of the jobs parameter
 	static const std::string jobs_name;
+
+	// Name of the production application ratio parameter
+	static const std::string production_application_ratio_name;
 
 	// Name of the PredicateNode outputting whether sources should be
 	// retried after exhaustion
@@ -146,11 +151,15 @@ private:
 		double complexity_penalty;
 
 		// This parameter controls the number of jobs used during
-		// reasoning. Note that the number of jobs can have an effect on
-		// the results, especially for the forward chainer because the
-		// result of applying a rule may depend on the output of
-		// applying other rules.
+		// reasoning.
 		int jobs;
+
+		// This parameter controls how many tuples -- (source, rule) for
+		// forward chainer or (inference, premise, rule) for backward
+		// chainer -- are produced in average before an application
+		// takes place. The higher the more tuples to choose from, which
+		// can lead to better inference control.
+		double production_application_ratio;
 	};
 	CommonParameters _common_params;
 

--- a/opencog/ure/backwardchainer/BIT.cc
+++ b/opencog/ure/backwardchainer/BIT.cc
@@ -808,10 +808,7 @@ bool BIT::andbits_exhausted() const
 bool BIT::is_in(const RuleTypedSubstitutionPair& rule,
                 const BITNode& bitnode) const
 {
-	for (const auto& bnr : bitnode.rules)
-		if (rule.first.is_alpha_equivalent(bnr.first))
-			return true;
-	return false;
+	return bitnode.rules.find(rule.first) != bitnode.rules.end();
 }
 
 std::string oc_to_string(const BITNode& bitnode, const std::string& indent)

--- a/opencog/ure/backwardchainer/ControlPolicy.cc
+++ b/opencog/ure/backwardchainer/ControlPolicy.cc
@@ -47,8 +47,8 @@ ControlPolicy::ControlPolicy(const UREConfig& ure_config, const BIT& bit,
 {
 	// Fetch default TVs for each inference rule (the TV on the member
 	// link connecting the rule to the rule base)
-	for (const Rule& rule : rules) {
-		_default_tvs[rule.get_alias()] = rule.get_tv();
+	for (RulePtr rule : rules) {
+		_default_tvs[rule->get_alias()] = rule->get_tv();
 	}
 	std::stringstream ss;
 	ss << "Default inference rule TVs:";
@@ -109,10 +109,10 @@ RuleTypedSubstitutionMap ControlPolicy::get_valid_rules(const AndBIT& andbit,
 {
 	// Generate all valid rules
 	RuleTypedSubstitutionMap valid_rules;
-	for (const Rule& rule : rules) {
+	for (RulePtr rule : rules) {
 		// For now ignore meta rules as they are forwardly applied in
 		// expand_bit()
-		if (rule.is_meta())
+		if (rule->is_meta())
 			continue;
 
 		// Get the leaf vardecl from fcs. We don't want to filter it
@@ -124,7 +124,7 @@ RuleTypedSubstitutionMap ControlPolicy::get_valid_rules(const AndBIT& andbit,
 			vardecl = BindLinkCast(andbit.fcs)->get_vardecl();
 
 		RuleTypedSubstitutionMap unified_rules
-			= rule.unify_target(bitleaf.body, vardecl);
+			= rule->unify_target(bitleaf.body, vardecl);
 
 		// Only insert unexplored rules for this leaf
 		RuleTypedSubstitutionMap pos_rules;

--- a/opencog/ure/forwardchainer/CMakeLists.txt
+++ b/opencog/ure/forwardchainer/CMakeLists.txt
@@ -2,5 +2,6 @@ INSTALL (FILES
 	FCStat.h
 	ForwardChainer.h
 	SourceSet.h
+	SourceRuleSet.h
 	DESTINATION "include/opencog/ure/forwardchainer"
 )

--- a/opencog/ure/forwardchainer/FCStat.h
+++ b/opencog/ure/forwardchainer/FCStat.h
@@ -73,7 +73,7 @@ private:
 	std::vector<InferenceRecord> _inf_rec;
 	AtomSpace* _trace_as;
 
-	// NEXT TODO: subdivide in smaller and shared mutexes
+	// TODO: subdivide in smaller and shared mutexes
 	mutable std::mutex _whole_mutex;
 };
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -449,10 +449,10 @@ SourceRule ForwardChainer::select_source_rule(const std::string& msgprfx)
 	if (not success)
 		return nullptr;
 	source->set_rule_exhausted(*rule_it); // TODO: We might want to do
-													  // that after application, to
-													  // avoid memory corruption
-													  // from calling too early
-													  // SourceSet::reset_exhausted()
+	                                      // that after application, to
+	                                      // avoid memory corruption
+	                                      // from calling too early
+	                                      // SourceSet::reset_exhausted()
 	return SourceRule(source, &*rule_it);
 }
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -221,7 +221,8 @@ void ForwardChainer::do_step(int iteration)
 		                   << " of success:" << std::endl << rule.to_string();
 	}
 
-	if (source->insert_rule(rule)) {
+	auto [_, success] = source->insert_rule(rule);
+	if (success) {
 		// Apply rule on source
 		HandleSet products = apply_rule(rule);
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -469,7 +469,8 @@ SourceRule ForwardChainer::mk_source_rule(const std::string& msgprfx)
 
 void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 {
-	LAZY_URE_LOG_DEBUG << msgprfx << "Populate the source rule set";
+	LAZY_URE_LOG_DEBUG << msgprfx << "Populate the source rule set (size="
+	                   << _source_rule_set.size() << ")";
 
 	int ratio = std::max((int)_config.get_production_application_ratio(), 1);
 	for (int i = 0; i < ratio; i++) {
@@ -479,7 +480,7 @@ void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 			LAZY_URE_LOG_DEBUG << msgprfx
 			                   << "Failed to build a source rule pair, "
 			                   << "abort populating source rule set";
-			return;
+			break;
 		}
 
 		// Insert it to the source rule set
@@ -492,14 +493,15 @@ void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 			                   << "already in the source rule set";
 		}
 	}
+
+	LAZY_URE_LOG_DEBUG << msgprfx << "Source rule set after population (size="
+	                   << _source_rule_set.size() << ")";
+	LAZY_URE_LOG_FINE << msgprfx << std::endl << _source_rule_set.to_string();
 }
 
 std::pair<SourceRule, TruthValuePtr>
 ForwardChainer::select_source_rule(const std::string& msgprfx)
 {
-	LAZY_URE_LOG_FINE << msgprfx
-	                  << "Select source rule pair from pool:" << std::endl
-	                  << _source_rule_set.to_string();
 	return _source_rule_set.thompson_select();
 }
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -481,7 +481,8 @@ void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 		TruthValuePtr tv = calculate_source_rule_tv(sr);
 		bool success = _source_rule_set.insert(sr, tv);
 		if (not success) {
-			LAZY_URE_LOG_DEBUG << "Source rule pair:" << std::endl
+			LAZY_URE_LOG_DEBUG << msgprfx
+			                   << "Source rule pair:" << std::endl
 			                   << oc_to_string(sr) << std::endl
 			                   << "already in the source rule set";
 		}

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -238,7 +238,7 @@ void ForwardChainer::do_step(int iteration)
 		LAZY_URE_LOG_DEBUG << msgprfx << "Rule " << rule.to_short_string()
 		                   << " is probably being applied on source "
 		                   << source->body->id_to_string()
-		                   << " in another thread. Abort iteration.";
+		                   << " in another thread, abort iteration";
 	}
 }
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -308,8 +308,8 @@ bool ForwardChainer::termination()
 {
 	bool terminate = false;
 
-	// Terminate if all sources have been tried
-	if (_sources.is_exhausted()) {
+	// Terminate if all source rule pairs have been tried
+	if (_sources.is_exhausted() and _source_rule_set.empty()) {
 		terminate = true;
 	}
 	// Terminate if max iterations has been reached
@@ -326,8 +326,8 @@ void ForwardChainer::termination_log()
 	std::string msg;
 
 	// Terminate if all sources have been tried
-	if (_sources.is_exhausted()) {
-		msg = "all sources have been exhausted";
+	if (_sources.is_exhausted() and _source_rule_set.empty()) {
+		msg = "all source rule pairs have been exhausted";
 	}
 	// Terminate if max iterations has been reached
 	else if (0 <= _config.get_maximum_iterations() and

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -458,21 +458,24 @@ SourceRule ForwardChainer::select_source_rule(const std::string& msgprfx)
 
 void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 {
-	// Build (source, rule) pair for application trial
-	SourceRule sr = select_source_rule(msgprfx);
-	if (not sr.is_valid()) {
-		LAZY_URE_LOG_DEBUG << msgprfx
-		                   << "Failed to build a source rule pair, "
-		                   << "abort populating source rule set";
-		return;
-	}
+	int par = std::max((int)_config.get_production_application_ratio(), 1);
+	for (int i = 0; i < par; i++) {
+		// Build (source, rule) pair for application trial
+		SourceRule sr = select_source_rule(msgprfx);
+		if (not sr.is_valid()) {
+			LAZY_URE_LOG_DEBUG << msgprfx
+			                   << "Failed to build a source rule pair, "
+			                   << "abort populating source rule set";
+			return;
+		}
 
-	// Insert this source rule pair to the source rule set
-	bool success = _source_rule_set.insert(sr, TruthValue::DEFAULT_TV() /* NEXT TODO */);
-	if (not success) {
-		LAZY_URE_LOG_DEBUG << "Source rule pair:" << std::endl
-		                   << oc_to_string(sr) << std::endl
-		                   << "already in the source rule set";
+		// Insert it to the source rule set
+		bool success = _source_rule_set.insert(sr, TruthValue::DEFAULT_TV() /* NEXT TODO */);
+		if (not success) {
+			LAZY_URE_LOG_DEBUG << "Source rule pair:" << std::endl
+			                   << oc_to_string(sr) << std::endl
+			                   << "already in the source rule set";
+		}
 	}
 }
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -449,7 +449,8 @@ SourceRule ForwardChainer::mk_source_rule(const std::string& msgprfx)
 
 	if (valid_rules.empty()) {
 		source->set_exhausted();
-		return SourceRule();
+		// Try again, in case another source is available
+		return mk_source_rule(msgprfx);
 	}
 
 	RulePtr slc_rule = rand_element(valid_rules);
@@ -478,7 +479,6 @@ void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 			LAZY_URE_LOG_DEBUG << msgprfx
 			                   << "Failed to build a source rule pair, "
 			                   << "abort populating source rule set";
-			// NEXT probably too strict
 			return;
 		}
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -440,7 +440,7 @@ SourceRule ForwardChainer::mk_source_rule(const std::string& msgprfx)
 	if (ure_logger().is_debug_enabled()) {
 		std::stringstream ss;
 		if (valid_rules.empty())
-			ss << msgprfx << "No valid rule";
+			ss << msgprfx << "No valid rule for that source. Let's try again";
 		else
 			ss << msgprfx << "The following rules are valid:" << std::endl
 			   << valid_rules.to_short_string();
@@ -468,6 +468,8 @@ SourceRule ForwardChainer::mk_source_rule(const std::string& msgprfx)
 
 void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 {
+	LAZY_URE_LOG_DEBUG << msgprfx << "Populate the source rule set";
+
 	int ratio = std::max((int)_config.get_production_application_ratio(), 1);
 	for (int i = 0; i < ratio; i++) {
 		// Build (source, rule) pair for application trial

--- a/opencog/ure/forwardchainer/ForwardChainer.h
+++ b/opencog/ure/forwardchainer/ForwardChainer.h
@@ -172,6 +172,11 @@ private:
 	void populate_source_rule_set(const std::string& msgprfx);
 
 	/**
+	 * Given a source rule pair, calculate its truth value of success.
+	 */
+	TruthValuePtr calculate_source_rule_tv(const SourceRule& sr);
+
+	/**
 	 * Get rules that unify with the source and that are not exhausted,
 	 * which include rules currently being run.
 	 */

--- a/opencog/ure/forwardchainer/ForwardChainer.h
+++ b/opencog/ure/forwardchainer/ForwardChainer.h
@@ -29,6 +29,7 @@
 
 #include "../UREConfig.h"
 #include "SourceSet.h"
+#include "SourceRuleSet.h"
 #include "FCStat.h"
 
 class ForwardChainerUTest;
@@ -101,10 +102,20 @@ public:
 	void do_steps_multithread();
 
 	/**
+	 * Source rule producer implementation of do_steps.
+	 */
+	void do_steps_srpi();
+
+	/**
 	 * Perform a single forward chaining inference step on the given
 	 * iteration.
 	 */
 	void do_step(int iteration);
+
+	/**
+	 * Source rule producer implementation of do_step.
+	 */
+	void do_step_srpi(int iteration);
 
 	/**
 	 * @return true if the termination criteria have been met.
@@ -151,6 +162,16 @@ private:
 	Source* select_source(const std::string& msgprfx);
 
 	/**
+	 * Build a source rule pair for application trial.
+	 */
+	SourceRule select_source_rule(const std::string& msgprfx);
+
+	/**
+	 * Populate the source rule set with pairs
+	 */
+	void populate_source_rule_set(const std::string& msgprfx);
+
+	/**
 	 * Get rules that unify with the source and that are not exhausted,
 	 * which include rules currently being run.
 	 */
@@ -177,6 +198,7 @@ private:
 	 * Apply rule.
 	 */
 	HandleSet apply_rule(const Rule& rule);
+	HandleSet apply_rule(const SourceRule& sr);
 
 	RuleSet _rules; /* loaded rules */
 
@@ -214,6 +236,14 @@ private:
 	SourceSet _sources;
 
 	FCStat _fcstat;
+
+	// Enable alternative implementation using (source, rule) producer,
+	// srpi stands for Source Rule Producer Implementation. This flag
+	// is here, likely temporarily, to compare old and new way.
+	const bool _srpi;
+
+	// Set of weighted pairs (source, rule).
+	SourceRuleSet _source_rule_set;
 };
 
 } // ~namespace opencog

--- a/opencog/ure/forwardchainer/ForwardChainer.h
+++ b/opencog/ure/forwardchainer/ForwardChainer.h
@@ -46,7 +46,7 @@ class Rule;
 
 // Pair of Rule and its probability estimate that it fullfils the
 // objective
-typedef std::pair<Rule, double> RuleProbabilityPair;
+typedef std::pair<RulePtr, double> RuleProbabilityPair;
 
 class ForwardChainer
 {
@@ -159,17 +159,23 @@ private:
 	 * Warning: it is not const because the source is gonna be modified
 	 * by keeping track of the rules applied to it.
 	 */
-	Source* select_source(const std::string& msgprfx);
+	SourcePtr select_source(const std::string& msgprfx);
 
 	/**
 	 * Build a source rule pair for application trial.
 	 */
-	SourceRule select_source_rule(const std::string& msgprfx);
+	SourceRule mk_source_rule(const std::string& msgprfx);
 
 	/**
 	 * Populate the source rule set with pairs
 	 */
 	void populate_source_rule_set(const std::string& msgprfx);
+
+	/**
+	 * Select source rule pair
+	 */
+	std::pair<SourceRule, TruthValuePtr>
+	select_source_rule(const std::string& msgprfx);
 
 	/**
 	 * Given a source rule pair, calculate its truth value of success.

--- a/opencog/ure/forwardchainer/ForwardChainer.h
+++ b/opencog/ure/forwardchainer/ForwardChainer.h
@@ -162,7 +162,8 @@ private:
 	SourcePtr select_source(const std::string& msgprfx);
 
 	/**
-	 * Build a source rule pair for application trial.
+	 * Build a source rule pair for application trial. If and only if
+	 * no such pair is available, then return an invalid pair.
 	 */
 	SourceRule mk_source_rule(const std::string& msgprfx);
 

--- a/opencog/ure/forwardchainer/SourceRuleSet.cc
+++ b/opencog/ure/forwardchainer/SourceRuleSet.cc
@@ -1,0 +1,118 @@
+/*
+ * SourceRuleSet.cc
+ *
+ * Copyright (C) 2020 SingularityNET Foundation
+ * Author: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "SourceRuleSet.h"
+
+#include <boost/range/algorithm/lower_bound.hpp>
+#include <boost/algorithm/cxx11/all_of.hpp>
+
+#include <opencog/util/oc_assert.h>
+
+namespace opencog {
+
+SourceRule::SourceRule(Source* src, Rule* rl)
+	: source(src), rule(rl)
+{
+}
+
+SourceRule::~SourceRule()
+{
+}
+
+bool SourceRule::operator==(const SourceRule& other) const
+{
+	return &source == &other.source and &rule == &other.rule;
+}
+
+bool SourceRule::operator<(const SourceRule& other) const
+{
+	return (&source < &other.source)
+		or (&source == &other.source and &rule < &other.rule);
+}
+
+bool SourceRule::is_valid() const
+{
+	return source != nullptr and rule != nullptr;
+}
+	
+SourceRuleSet::SourceRuleSet()
+	: _thompson_smp(tvs)
+{
+}
+	
+bool SourceRuleSet::insert(const SourceRule& sr, TruthValuePtr tv)
+{
+	auto it = boost::lower_bound(source_rule_seq, sr);
+	if (it == source_rule_seq.end() or *it != sr) {
+		it = source_rule_seq.insert(it, sr);
+		size_t idx = std::distance(source_rule_seq.begin(), it);
+		tvs.insert(std::next(tvs.begin(), idx), tv);
+		return true;
+	}
+	// The pair is already in the source rule set
+	return false;
+}
+
+SourceRule SourceRuleSet::thompson_select()
+{
+	if (tvs.empty())
+		return SourceRule();
+
+	// Select the next source rule pair to apply
+	size_t rnd_idx = _thompson_smp();
+	SourceRule slc_sr = source_rule_seq[rnd_idx];
+
+	// Remove it from the container to not be selected again
+	source_rule_seq.erase(std::next(source_rule_seq.begin(), rnd_idx));
+	tvs.erase(std::next(tvs.begin(), rnd_idx));
+
+	// Return the selected source rule pair
+	return slc_sr;
+}
+
+std::string oc_to_string(const SourceRule& sr, const std::string& indent)
+{
+	static const std::string nullstr("nullptr");
+	std::stringstream ss;
+	// Only print hash because not the master container
+	ss << indent << "source: "
+		<< (sr.source ? sr.source->body->id_to_string() : nullstr)
+		<< std::endl << indent << "rule: "
+		<< (sr.rule ? sr.rule->to_short_string() : nullstr);
+	return ss.str();
+}
+
+std::string oc_to_string(const SourceRuleSet& srs, const std::string& indent)
+{
+	std::stringstream ss;
+	std::string indent2 = indent + oc_to_string_indent;
+	ss << indent << "size = " << srs.source_rule_seq.size();
+	size_t i = 0;
+	for (const SourceRule& sr : srs.source_rule_seq) {
+		ss << std::endl << indent << "source,rule[" << i << "]:"
+			<< std::endl << oc_to_string(sr, indent2);
+		i++;
+	}
+	return ss.str();
+}
+
+} // ~namespace opencog

--- a/opencog/ure/forwardchainer/SourceRuleSet.cc
+++ b/opencog/ure/forwardchainer/SourceRuleSet.cc
@@ -55,7 +55,7 @@ bool SourceRule::is_valid() const
 }
 
 SourceRuleSet::SourceRuleSet()
-	: _thompson_smp(tvs)
+	: _thompson_smp(tv_seq)
 {
 }
 
@@ -65,28 +65,29 @@ bool SourceRuleSet::insert(const SourceRule& sr, TruthValuePtr tv)
 	if (it == source_rule_seq.end() or *it != sr) {
 		it = source_rule_seq.insert(it, sr);
 		size_t idx = std::distance(source_rule_seq.begin(), it);
-		tvs.insert(std::next(tvs.begin(), idx), tv);
+		tv_seq.insert(std::next(tv_seq.begin(), idx), tv);
 		return true;
 	}
 	// The pair is already in the source rule set
 	return false;
 }
 
-SourceRule SourceRuleSet::thompson_select()
+std::pair<SourceRule, TruthValuePtr> SourceRuleSet::thompson_select()
 {
-	if (tvs.empty())
-		return SourceRule();
+	if (tv_seq.empty())
+		return {SourceRule(), nullptr};
 
 	// Select the next source rule pair to apply
 	size_t rnd_idx = _thompson_smp();
 	SourceRule slc_sr = source_rule_seq[rnd_idx];
+	TruthValuePtr slc_tv = tv_seq[rnd_idx];
 
 	// Remove it from the container to not be selected again
 	source_rule_seq.erase(std::next(source_rule_seq.begin(), rnd_idx));
-	tvs.erase(std::next(tvs.begin(), rnd_idx));
+	tv_seq.erase(std::next(tv_seq.begin(), rnd_idx));
 
 	// Return the selected source rule pair
-	return slc_sr;
+	return {slc_sr, slc_tv};
 }
 
 std::string oc_to_string(const SourceRule& sr, const std::string& indent)

--- a/opencog/ure/forwardchainer/SourceRuleSet.cc
+++ b/opencog/ure/forwardchainer/SourceRuleSet.cc
@@ -102,6 +102,16 @@ std::pair<SourceRule, TruthValuePtr> SourceRuleSet::thompson_select()
 	return {slc_sr, slc_tv};
 }
 
+bool SourceRuleSet::empty() const
+{
+	return source_rule_seq.empty();
+}
+
+size_t SourceRuleSet::size() const
+{
+	return source_rule_seq.size();
+}
+
 std::string SourceRuleSet::to_string(const std::string& indent) const
 {
 	std::stringstream ss;

--- a/opencog/ure/forwardchainer/SourceRuleSet.cc
+++ b/opencog/ure/forwardchainer/SourceRuleSet.cc
@@ -53,12 +53,12 @@ bool SourceRule::is_valid() const
 {
 	return source != nullptr and rule != nullptr;
 }
-	
+
 SourceRuleSet::SourceRuleSet()
 	: _thompson_smp(tvs)
 {
 }
-	
+
 bool SourceRuleSet::insert(const SourceRule& sr, TruthValuePtr tv)
 {
 	auto it = boost::lower_bound(source_rule_seq, sr);
@@ -95,9 +95,9 @@ std::string oc_to_string(const SourceRule& sr, const std::string& indent)
 	std::stringstream ss;
 	// Only print hash because not the master container
 	ss << indent << "source: "
-		<< (sr.source ? sr.source->body->id_to_string() : nullstr)
-		<< std::endl << indent << "rule: "
-		<< (sr.rule ? sr.rule->to_short_string() : nullstr);
+	   << (sr.source ? sr.source->body->id_to_string() : nullstr)
+	   << std::endl << indent << "rule: "
+	   << (sr.rule ? sr.rule->to_short_string() : nullstr);
 	return ss.str();
 }
 
@@ -109,7 +109,7 @@ std::string oc_to_string(const SourceRuleSet& srs, const std::string& indent)
 	size_t i = 0;
 	for (const SourceRule& sr : srs.source_rule_seq) {
 		ss << std::endl << indent << "source,rule[" << i << "]:"
-			<< std::endl << oc_to_string(sr, indent2);
+		   << std::endl << oc_to_string(sr, indent2);
 		i++;
 	}
 	return ss.str();

--- a/opencog/ure/forwardchainer/SourceRuleSet.cc
+++ b/opencog/ure/forwardchainer/SourceRuleSet.cc
@@ -29,7 +29,7 @@
 
 namespace opencog {
 
-SourceRule::SourceRule(Source* src, Rule* rl)
+SourceRule::SourceRule(SourcePtr src, RulePtr rl)
 	: source(src), rule(rl)
 {
 }
@@ -52,6 +52,18 @@ bool SourceRule::operator<(const SourceRule& other) const
 bool SourceRule::is_valid() const
 {
 	return source != nullptr and rule != nullptr;
+}
+
+std::string SourceRule::to_string(const std::string& indent) const
+{
+	static const std::string nullstr("nullptr");
+	std::stringstream ss;
+	// Only print hash because not the master container
+	ss << indent << "source[" << source << "]: "
+	   << (source ? source->body->id_to_string() : nullstr)
+	   << std::endl << indent << "rule[" << rule << "]: "
+	   << (rule ? rule->to_short_string() : nullstr);
+	return ss.str();
 }
 
 SourceRuleSet::SourceRuleSet()
@@ -90,30 +102,28 @@ std::pair<SourceRule, TruthValuePtr> SourceRuleSet::thompson_select()
 	return {slc_sr, slc_tv};
 }
 
+std::string SourceRuleSet::to_string(const std::string& indent) const
+{
+	std::stringstream ss;
+	std::string indent2 = indent + oc_to_string_indent;
+	ss << indent << "size = " << source_rule_seq.size();
+	size_t i = 0;
+	for (const SourceRule& sr : source_rule_seq) {
+		ss << std::endl << indent << "(source,rule)[" << i << "]:"
+		   << std::endl << sr.to_string(indent2);
+		i++;
+	}
+	return ss.str();
+}
+
 std::string oc_to_string(const SourceRule& sr, const std::string& indent)
 {
-	static const std::string nullstr("nullptr");
-	std::stringstream ss;
-	// Only print hash because not the master container
-	ss << indent << "source: "
-	   << (sr.source ? sr.source->body->id_to_string() : nullstr)
-	   << std::endl << indent << "rule: "
-	   << (sr.rule ? sr.rule->to_short_string() : nullstr);
-	return ss.str();
+	return sr.to_string(indent);
 }
 
 std::string oc_to_string(const SourceRuleSet& srs, const std::string& indent)
 {
-	std::stringstream ss;
-	std::string indent2 = indent + oc_to_string_indent;
-	ss << indent << "size = " << srs.source_rule_seq.size();
-	size_t i = 0;
-	for (const SourceRule& sr : srs.source_rule_seq) {
-		ss << std::endl << indent << "source,rule[" << i << "]:"
-		   << std::endl << oc_to_string(sr, indent2);
-		i++;
-	}
-	return ss.str();
+	return srs.to_string(indent);
 }
 
 } // ~namespace opencog

--- a/opencog/ure/forwardchainer/SourceRuleSet.h
+++ b/opencog/ure/forwardchainer/SourceRuleSet.h
@@ -85,12 +85,11 @@ public:
 	bool insert(const SourceRule& sr, TruthValuePtr tv);
 
 	/**
-	 * Select a pair according to Thompson sampling. The most
-	 * expansive, but also the most accurate way to select. Then set
-	 * the weight of the selected pair to null in order not to select
-	 * it again.
+	 * Select a pair according to Thompson sampling and remove it from
+	 * the set. Return the empty source rule pair, and the nullptr
+	 * truth value if the set is empty.
 	 */
-	SourceRule thompson_select();
+	std::pair<SourceRule, TruthValuePtr> thompson_select();
 
 	// TODO: implement tournament selection as well, as a cheaper
 	// alternative to Thompson sampling.
@@ -98,13 +97,14 @@ public:
 	// Ordered sequence of source rule pairs.
 	std::vector<SourceRule> source_rule_seq;
 
-	// Ordered sequence of tvs, representing the second order weights
-	// of each source rule pair. In the same order as source_rule_seq.
+	// Ordered sequence of Truth Values, representing the second order
+	// weights of each source rule pair. In the same order as
+	// source_rule_seq.
 	//
 	// It's easier here to have a sequence of TVs as opposed to having
 	// having weighted pairs because Thompson sampling takes in a
 	// sequence of TVs.
-	TruthValueSeq tvs;
+	TruthValueSeq tv_seq;
 
 private:
 	ThompsonSampling _thompson_smp;

--- a/opencog/ure/forwardchainer/SourceRuleSet.h
+++ b/opencog/ure/forwardchainer/SourceRuleSet.h
@@ -111,10 +111,10 @@ private:
 };
 
 std::string oc_to_string(const SourceRule& sr,
-								 const std::string& indent=empty_string);
+                         const std::string& indent=empty_string);
 std::string oc_to_string(const SourceRuleSet& srs,
-								 const std::string& indent=empty_string);
-	
+                         const std::string& indent=empty_string);
+
 } // ~namespace opencog
 
 #endif /* _OPENCOG_SOURCERULESET_H_ */

--- a/opencog/ure/forwardchainer/SourceRuleSet.h
+++ b/opencog/ure/forwardchainer/SourceRuleSet.h
@@ -1,0 +1,120 @@
+/*
+ * SourceSet.h
+ *
+ * Copyright (C) 2020 SingularityNET Foundation
+ *
+ * Author: Nil Geisweiller <ngeiswei@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_SOURCERULESET_H_
+#define _OPENCOG_SOURCERULESET_H_
+
+#include <opencog/util/empty_string.h>
+
+#include "../ThompsonSampling.h"
+
+#include "SourceSet.h"
+
+namespace opencog
+{
+
+/**
+ * Pair of source and rule, actually pointers as not primary owner.
+ */
+class SourceRule : public boost::totally_ordered<SourceRule>
+{
+public:
+	SourceRule(Source* src=nullptr, Rule* rule=nullptr);
+	~SourceRule();
+
+	/**
+	 * Comparison operators. Based on src and rule, not tv, as indeed
+	 * such tv depends on the inference path leading to that (source,
+	 * rule) pair, thus would fail to capture confluence.
+	 */
+	bool operator==(const SourceRule& other) const;
+	bool operator<(const SourceRule& other) const;
+
+	/**
+	 * Return true iff the pair is valid, that is both source and rule
+	 * pointers are non null.
+	 */
+	bool is_valid() const;
+
+	// Pointers of source and rule from other master
+	// containers. Although these pointers are never null, we use
+	// pointers instead of references to avoid re-implementing
+	// SourceRule::operator=().
+	Source* source;
+	Rule* rule;
+};
+
+/**
+ * Class holding (source, rule) reference pairs to be selected and
+ * applied. Each pair is weighted by a second order probability of
+ * success, thus the selector must turn these second order
+ * probabilities of success into first order probabilities of action
+ * via Thompson sampling ideally, or less ideally but possibly more
+ * efficiently tournament selection.
+ */
+class SourceRuleSet
+{
+public:
+	SourceRuleSet();
+
+	/**
+	 * Insert (source, rule) pair in the container, alongside it's
+	 * second order probability of success. Return false if insertion
+	 * fails, that is such pair already exists in the container.
+	 */
+	bool insert(const SourceRule& sr, TruthValuePtr tv);
+
+	/**
+	 * Select a pair according to Thompson sampling. The most
+	 * expansive, but also the most accurate way to select. Then set
+	 * the weight of the selected pair to null in order not to select
+	 * it again.
+	 */
+	SourceRule thompson_select();
+
+	// TODO: implement tournament selection as well, as a cheaper
+	// alternative to Thompson sampling.
+
+	// Ordered sequence of source rule pairs.
+	std::vector<SourceRule> source_rule_seq;
+
+	// Ordered sequence of tvs, representing the second order weights
+	// of each source rule pair. In the same order as source_rule_seq.
+	//
+	// It's easier here to have a sequence of TVs as opposed to having
+	// having weighted pairs because Thompson sampling takes in a
+	// sequence of TVs.
+	TruthValueSeq tvs;
+
+private:
+	ThompsonSampling _thompson_smp;
+};
+
+std::string oc_to_string(const SourceRule& sr,
+								 const std::string& indent=empty_string);
+std::string oc_to_string(const SourceRuleSet& srs,
+								 const std::string& indent=empty_string);
+	
+} // ~namespace opencog
+
+#endif /* _OPENCOG_SOURCERULESET_H_ */

--- a/opencog/ure/forwardchainer/SourceRuleSet.h
+++ b/opencog/ure/forwardchainer/SourceRuleSet.h
@@ -101,6 +101,16 @@ public:
 	// alternative to Thompson sampling.
 
 	/**
+	 * Return true iff the pool is empty
+	 */
+	bool empty() const;
+
+	/**
+	 * Return the number of source rule pairs in the container
+	 */
+	size_t size() const;
+
+	/**
 	 * Turn the source rule pool into a string representation. Useful
 	 * for debugging.
 	 */

--- a/opencog/ure/forwardchainer/SourceRuleSet.h
+++ b/opencog/ure/forwardchainer/SourceRuleSet.h
@@ -39,7 +39,7 @@ namespace opencog
 class SourceRule : public boost::totally_ordered<SourceRule>
 {
 public:
-	SourceRule(Source* src=nullptr, Rule* rule=nullptr);
+	SourceRule(SourcePtr src=nullptr, RulePtr rule=nullptr);
 	~SourceRule();
 
 	/**
@@ -56,12 +56,18 @@ public:
 	 */
 	bool is_valid() const;
 
+	/**
+	 * Turn the pair into a string representation. Useful for
+	 * debugging.
+	 */
+	std::string to_string(const std::string& indent=empty_string) const;
+
 	// Pointers of source and rule from other master
 	// containers. Although these pointers are never null, we use
 	// pointers instead of references to avoid re-implementing
 	// SourceRule::operator=().
-	Source* source;
-	Rule* rule;
+	SourcePtr source;
+	RulePtr rule;
 };
 
 /**
@@ -93,6 +99,12 @@ public:
 
 	// TODO: implement tournament selection as well, as a cheaper
 	// alternative to Thompson sampling.
+
+	/**
+	 * Turn the source rule pool into a string representation. Useful
+	 * for debugging.
+	 */
+	std::string to_string(const std::string& indent=empty_string) const;
 
 	// Ordered sequence of source rule pairs.
 	std::vector<SourceRule> source_rule_seq;

--- a/opencog/ure/forwardchainer/SourceSet.cc
+++ b/opencog/ure/forwardchainer/SourceSet.cc
@@ -102,6 +102,14 @@ bool Source::is_rule_exhausted(const Rule& rule) const
 {
 	std::lock_guard<std::mutex> lock(_mutex);
 	for (const Rule& r : rules)
+		// Note that the presence of an alpha-equivalent rule in the
+		// source is not enough to being considered exhausted, the
+		// exhausted flag of the rule must also be explicited set to
+		// true. That is in order to possibly make the distinction
+		// between a rule that is being tried and a rule that has
+		// already been tried. It's not clear though whether we need
+		// this distinction, and if we do we probably should make it
+		// explicit in the Source or Rule API.
 		if (rule.is_alpha_equivalent(r) and r.is_exhausted())
 			return true;
 	return false;

--- a/opencog/ure/forwardchainer/SourceSet.cc
+++ b/opencog/ure/forwardchainer/SourceSet.cc
@@ -55,7 +55,7 @@ Source::Source(const Handle& bdy, const Handle& vdcl, double cpx, double cpx_fct
 
 bool Source::operator==(const Source& other) const
 {
-	return body == other.body && vardecl == other.vardecl;
+	return content_eq(body, other.body) and content_eq(vardecl, other.vardecl);
 }
 
 bool Source::operator<(const Source& other) const
@@ -277,7 +277,7 @@ std::string oc_to_string(const SourceSet::Sources& sources, const std::string& i
 	ss << indent << "size = " << sources.size() << std::endl;
 	size_t i = 0;
 	for (const Source& src : sources) {
-		ss << indent << "Source[" << i << "]:" << std::endl
+		ss << indent << "source[" << i << "]:" << std::endl
 		   << src.to_string(indent + oc_to_string_indent);
 		i++;
 	}

--- a/opencog/ure/forwardchainer/SourceSet.cc
+++ b/opencog/ure/forwardchainer/SourceSet.cc
@@ -39,8 +39,13 @@ double calculate_weight(const Handle& bdy, double cpx_fctr)
 	//
 	// The minimum value is 1e-16 to not ignore completely the source
 	// when the it is a default TV.
+	//
+	// TODO:
+	// 1. Support more fitness functions
+	// 2. Explicitely turn the fitness into a probability of success
 	TruthValuePtr tv = bdy->getTruthValue();
-	return std::max(1e-16, cpx_fctr * tv->get_mean() * tv->get_confidence());
+	double fitness = tv->get_mean() * tv->get_confidence();
+	return std::max(1e-16, cpx_fctr * fitness);
 }
 
 Source::Source(const Handle& bdy, const Handle& vdcl, double cpx, double cpx_fctr)

--- a/opencog/ure/forwardchainer/SourceSet.cc
+++ b/opencog/ure/forwardchainer/SourceSet.cc
@@ -103,26 +103,23 @@ bool Source::is_exhausted() const
 void Source::set_rule_exhausted(const RulePtr& rule)
 {
 	std::lock_guard<std::mutex> lock(_mutex);
-	for (RulePtr r : rules)
-		if (rule->is_alpha_equivalent(*r))
-			r->set_exhausted();
+	auto it = rules.find(rule);
+	if (it != rules.end())
+		(*it)->set_exhausted();
 }
 
 bool Source::is_rule_exhausted(const RulePtr& rule) const
 {
 	std::lock_guard<std::mutex> lock(_mutex);
-	for (RulePtr r : rules)
-		// Note that the presence of an alpha-equivalent rule in the
-		// source is not enough to being considered exhausted, the
-		// exhausted flag of the rule must also be explicited set to
-		// true. That is in order to possibly make the distinction
-		// between a rule that is being tried and a rule that has
-		// already been tried. It's not clear though whether we need
-		// this distinction, and if we do we probably should make it
-		// explicit in the Source or Rule API.
-		if (rule->is_alpha_equivalent(*r) and r->is_exhausted())
-			return true;
-	return false;
+	auto it = rules.find(rule);
+	// Note that the presence of an alpha-equivalent rule in the source
+	// is not enough to being considered exhausted, the exhausted flag
+	// of the rule must also be explicited set to true. That is in
+	// order to possibly make the distinction between a rule that is
+	// being tried and a rule that has already been tried. It's not
+	// clear though whether we need this distinction, and if we do we
+	// probably should make it explicit in the Source or Rule API.
+	return it != rules.end() and (*it)->is_exhausted();
 }
 
 double Source::expand_complexity(double prob) const

--- a/opencog/ure/forwardchainer/SourceSet.cc
+++ b/opencog/ure/forwardchainer/SourceSet.cc
@@ -117,7 +117,7 @@ bool Source::is_rule_exhausted(const Rule& rule) const
 
 double Source::expand_complexity(double prob) const
 {
-	return complexity - log2(prob);
+	return complexity - std::log2(prob);
 }
 
 double Source::get_weight() const
@@ -208,7 +208,7 @@ void SourceSet::insert(const HandleSet& products, const Source& src,
 
 	// Calculate the complexity of the new sources
 	double new_cpx = src.expand_complexity(prob);
-	double new_cpx_fctr = exp(-_config.get_complexity_penalty() * new_cpx);
+	double new_cpx_fctr = std::exp2(-_config.get_complexity_penalty() * new_cpx);
 
 	// Keep all new sources
 	std::vector<Source*> new_srcs;

--- a/opencog/ure/forwardchainer/SourceSet.cc
+++ b/opencog/ure/forwardchainer/SourceSet.cc
@@ -65,7 +65,7 @@ bool Source::operator<(const Source& other) const
 		or (content_eq(body, other.body) and vardecl < other.vardecl);
 }
 
-bool Source::insert_rule(const Rule& rule)
+std::pair<RuleSet::iterator, bool> Source::insert_rule(const Rule& rule)
 {
 	std::lock_guard<std::mutex> lock(_mutex);
 	return rules.insert(rule);

--- a/opencog/ure/forwardchainer/SourceSet.h
+++ b/opencog/ure/forwardchainer/SourceSet.h
@@ -75,7 +75,7 @@ public:
 	 * applied. Return true if insertion is successful (that is if no
 	 * alpha-equivalent rule was already there).
 	 */
-	bool insert_rule(const Rule& rule);
+	std::pair<RuleSet::iterator, bool> insert_rule(const Rule& rule);
 
 	/**
 	 * Set exhausted flag to true

--- a/opencog/ure/forwardchainer/SourceSet.h
+++ b/opencog/ure/forwardchainer/SourceSet.h
@@ -75,7 +75,7 @@ public:
 	 * applied. Return true if insertion is successful (that is if no
 	 * alpha-equivalent rule was already there).
 	 */
-	std::pair<RuleSet::iterator, bool> insert_rule(const Rule& rule);
+	bool insert_rule(RulePtr rule);
 
 	/**
 	 * Set exhausted flag to true
@@ -95,12 +95,12 @@ public:
 	/**
 	 * Set the exhausted flag of that rule to true
 	 */
-	void set_rule_exhausted(const Rule& rule);
+	void set_rule_exhausted(const RulePtr& rule);
 
 	/**
 	 * Check if the given rule has been tried
 	 */
-	bool is_rule_exhausted(const Rule& rule) const;
+	bool is_rule_exhausted(const RulePtr& rule) const;
 
 	/**
 	 * Return the complexity of new source expanded from this source by
@@ -150,6 +150,13 @@ public:
 private:
 	// TODO: subdivide in smaller and shared mutexes
 	mutable std::mutex _mutex;
+};
+
+typedef std::shared_ptr<Source> SourcePtr;
+#define createSource std::make_shared<Source>
+struct source_ptr_less
+{
+	bool operator()(const SourcePtr& l, const SourcePtr& r) const;
 };
 
 /**
@@ -204,10 +211,7 @@ public:
 	// because the source being expanded is modified (it keeps track of
 	// its expansion rules). Alternatively we could use a set and
 	// define Sources::rules as mutable.
-	//
-	// A boost::ptr_vector is used because it is the main owner of
-	// sources, and such sources get deallocated upon destruction.
-	typedef boost::ptr_vector<Source> Sources;
+	typedef std::vector<SourcePtr> Sources;
 	Sources sources;
 
 	// True iff all sources have been tried

--- a/opencog/ure/forwardchainer/SourceSet.h
+++ b/opencog/ure/forwardchainer/SourceSet.h
@@ -127,10 +127,18 @@ public:
 
 	// Proxy for the prior probability of the source, taking into
 	// account the complexity penalty.
+	//
+	// Note that in case the complexity penalty is negative (which can
+	// be used for depth-first search) then the complexity factor can
+	// be greater than 1.0.
 	const double complexity_factor;
 
 	// Weight, akin to the unormalized probability of selecting that
 	// source.
+	//
+	// Note that in case the complexity penalty is negative (which can
+	// be used for depth-first search) then the weight can be greater
+	// than 1.0.
 	const double weight;
 
 	// True iff all rules that could expand the source have been tried

--- a/opencog/ure/forwardchainer/SourceSet.h
+++ b/opencog/ure/forwardchainer/SourceSet.h
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2018 SingularityNET Foundation
  *
- * Author: Nil Geisweiller
+ * Author: Nil Geisweiller <ngeiswei@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License v3 as
@@ -62,8 +62,10 @@ public:
 	       double complexity_factor=1.0);
 
 	/**
-	 * Comparison operators. For operator< compare by complexity, or by
-	 * handle value if they are of the same size.
+	 * Comparison operators. Only body and vardecl are used for
+	 * comparison, not the weight or complexity, because such
+	 * quantities depend on the inference path leading to the source,
+	 * thus would fail to capture confluence.
 	 */
 	bool operator==(const Source& other) const;
 	bool operator<(const Source& other) const;
@@ -134,16 +136,16 @@ public:
 	// True iff all rules that could expand the source have been tried
 	bool exhausted;
 
-	// Rules so far attempted on that source
+	// Rules so far attempted on that source. Primary owner.
 	RuleSet rules;
 
 private:
-	// NEXT TODO: subdivide in smaller and shared mutexes
+	// TODO: subdivide in smaller and shared mutexes
 	mutable std::mutex _mutex;
 };
 
 /**
- * Population of sources to forwardly expand.
+ * Population of sources to forwardly expand. Primary owner.
  */
 // TODO: this class has things in common with BIT, maybe their common
 // things could be placed in a parent class.
@@ -194,6 +196,9 @@ public:
 	// because the source being expanded is modified (it keeps track of
 	// its expansion rules). Alternatively we could use a set and
 	// define Sources::rules as mutable.
+	//
+	// A boost::ptr_vector is used because it is the main owner of
+	// sources, and such sources get deallocated upon destruction.
 	typedef boost::ptr_vector<Source> Sources;
 	Sources sources;
 
@@ -203,7 +208,7 @@ public:
 private:
 	const UREConfig& _config;
 
-	// NEXT TODO: subdivide in smaller and shared mutexes
+	// TODO: subdivide in smaller and shared mutexes
 	mutable std::mutex _mutex;
 };
 

--- a/tests/ure/RuleUTest.cxxtest
+++ b/tests/ure/RuleUTest.cxxtest
@@ -59,6 +59,7 @@ public:
 	void setUp();
 	void tearDown();
 
+	void test_insert_rule();
 	void test_unify_target_deduction_1();
 	void test_unify_target_deduction_2();
 	void test_unify_target_deduction_3();
@@ -148,6 +149,43 @@ void RuleUTest::setUp()
 void RuleUTest::tearDown()
 {
 	_as.clear();
+}
+
+void RuleUTest::test_insert_rule()
+{
+	// Insert rules to a source make sure that they
+	// 1. do not get disallocated
+	// 2. are content-based sorted
+	// 3. are unique
+
+	Rule deduction_rule(deduction_rule_h);
+	Rule implication_scope_to_implication_rule(implication_scope_to_implication_rule_h);
+
+	RuleSet rules1;
+	auto [di1, ds1] = rules1.insert(createRule(deduction_rule));
+	Rule* dr1 = (*di1).get();
+	auto [_, dup] = rules1.insert(createRule(deduction_rule));
+	auto [ii1, is1] = rules1.insert(createRule(implication_scope_to_implication_rule));
+	Rule* ir1 = (*ii1).get();
+
+	RuleSet rules2;
+	auto [ii2, is2] = rules2.insert(createRule(implication_scope_to_implication_rule));
+	Rule* ir2 = (*ii2).get();
+	auto [di2, ds2] = rules2.insert(createRule(deduction_rule));
+	Rule* dr2 = (*di2).get();
+
+	logger().debug() << "rules1:" << std::endl << rules1.to_short_string("  ");
+	logger().debug() << "rules2:" << std::endl << rules2.to_short_string("  ");
+
+	// Make sure rule pointers are still valid after insertion of other rules
+	TS_ASSERT_EQUALS(*dr1, *dr2);
+	TS_ASSERT_EQUALS(*ir1, *ir2);
+
+	// Make sure rules1 and rules2 are equal are ordered equally
+	TS_ASSERT_EQUALS(rules1, rules2);
+
+	// Check that inserting a duplicate fails
+	TS_ASSERT(not dup);
 }
 
 void RuleUTest::test_unify_target_deduction_1()

--- a/tests/ure/forwardchainer/ForwardChainerUTest.cxxtest
+++ b/tests/ure/forwardchainer/ForwardChainerUTest.cxxtest
@@ -118,7 +118,7 @@ void ForwardChainerUTest::test_select_rule(void)
 
 	// Full unification
 	RuleProbabilityPair rule = fc.select_rule(h);
-	TS_ASSERT(rule.first.is_valid());
+	TS_ASSERT(rule.first->is_valid());
 }
 
 void ForwardChainerUTest::test_deduction()

--- a/tests/ure/forwardchainer/ForwardChainerUTest.cxxtest
+++ b/tests/ure/forwardchainer/ForwardChainerUTest.cxxtest
@@ -80,7 +80,6 @@ public:
 	void test_fritz_green();
 	void test_tweety_not_green();
 	void test_fritz_green_alt();
-	// TODO: enable once https://github.com/opencog/ure/issues/33 is fixed
 	void test_tweety_not_green_alt();
 	void test_unsatisfied_premise();
 	void test_negation_conflict();

--- a/tests/ure/forwardchainer/scm/fc-animals-config.scm
+++ b/tests/ure/forwardchainer/scm/fc-animals-config.scm
@@ -7,28 +7,11 @@
 (load-from-path "tests/ure/meta-rules/conditional-full-instantiation-meta-rule.scm")
 (load-from-path "tests/ure/rules/fuzzy-conjunction-introduction-rule.scm")
 
-;; Associate the rules to the rule base (with weights, their semantics
-;; is currently undefined, we might settled with probabilities but it's
-;; not sure)
-(MemberLink (stv 1 1)
-   conditional-full-instantiation-meta-rule-name
-   (ConceptNode "URE")
-)
-(MemberLink (stv 1 1)
-   fuzzy-conjunction-introduction-2ary-rule-name
-   (ConceptNode "URE")
-)
+(define rbs (ConceptNode "URE"))
+
+;; Associate the rules to the rule base
+(ure-add-rules rbs (list conditional-full-instantiation-meta-rule-name
+			 fuzzy-conjunction-introduction-2ary-rule-name))
 
 ;; termination criteria parameters
-(ExecutionLink
-   (SchemaNode "URE:maximum-iterations")
-   (ConceptNode "URE")
-   (NumberNode "20")
-)
-
-;; Attention allocation (set the TV strength to 0 to disable it, 1 to
-;; enable it)
-(EvaluationLink (stv 0 1)
-   (PredicateNode "URE:attention-allocation")
-   (ConceptNode "URE")
-)
+(ure-set-maximum-iterations rbs 20)

--- a/tests/ure/forwardchainer/scm/fc-bindlink-no-vardecl-config.scm
+++ b/tests/ure/forwardchainer/scm/fc-bindlink-no-vardecl-config.scm
@@ -41,5 +41,3 @@
 (ure-add-rules rbs
                (list
                 (cons rule-name (stv 1 1))))
-
-

--- a/tests/ure/forwardchainer/scm/fc-config.scm
+++ b/tests/ure/forwardchainer/scm/fc-config.scm
@@ -32,7 +32,3 @@
 
 ; Termination criteria parameters
 (ure-set-num-parameter fc-rbs "URE:maximum-iterations" 20)
-
-; Attention allocation (set the TV strength to 0 to disable it, 1 to
-; enable it)
-(ure-set-fuzzy-bool-parameter fc-rbs "URE:attention-allocation" 0)

--- a/tests/ure/forwardchainer/scm/fc-deduction-config.scm
+++ b/tests/ure/forwardchainer/scm/fc-deduction-config.scm
@@ -27,8 +27,4 @@
 (ure-add-rules fc-deduction-rbs (list fc-deduction-rule-name))
 
 ;; Termination criteria parameters
-(ure-set-num-parameter fc-deduction-rbs "URE:maximum-iterations" 20)
-
-;; Attention allocation (set the TV strength to 0 to disable it, 1 to
-;; enable it)
-(ure-set-fuzzy-bool-parameter fc-deduction-rbs "URE:attention-allocation" 0)
+(ure-set-maximum-iterations fc-deduction-rbs 20)


### PR DESCRIPTION
1. Introduce a source x rule pair pool that the forward chainer can draw from to select its next application.
2. Store source and rules with shared pointers to avoid memory corruptions
3. Optimize rule insertion and retrieval (log instead of linear)

The most important change is item 1. that offers better out-of-the-box inference control as the source x rule pair selection is drawn from a potentially much bigger pool, controlled by the `production-application-ratio` user parameter.

Early experiments are showing promises, it allows to converge to the desired solutions with x2 less rule applications on a subsample (10%) of the bio-atomspace, with almost no tuning required. More thorough benchmarking will have to be made to better assess the performance gains.