### PR TITLE
MapLink no longer returns an invalid handle.

### DIFF
--- a/opencog/ure/backwardchainer/ControlPolicy.cc
+++ b/opencog/ure/backwardchainer/ControlPolicy.cc
@@ -324,7 +324,7 @@ bool ControlPolicy::match(const Handle& pattern, const Handle& term,
 		tmp_term = tmp_as.add_atom(term),
 		result = HandleCast(MapLink(impl, tmp_term).execute(&tmp_as, false));
 
-	return (bool)result;
+	return (SET_LINK != result->get_type()) or (result->get_arity() != 0);
 }
 
 Handle ControlPolicy::get_antecedent_preproof(const Handle& ctrl_rule) const


### PR DESCRIPTION
Commit opencog/atomspace#317c1c56e3e18c90b62dbbca62fc86deff46c69d
changed how MapLink works ... it no longer returns an invalid
handle. Returning the invalid handle resulted in bizarro memory
corruption, resulting in crashes in the destructor for `class Context`
and specifically, in the destructor for `std::list<Variables>`.
Getting rid of the null-pointer fixes some unknown null-pointer-deref
somewhere else... but it requires this change.