### PR TITLE
Optimize Thompson sampling

### DIFF
--- a/opencog/ure/BetaDistribution.cc
+++ b/opencog/ure/BetaDistribution.cc
@@ -38,6 +38,11 @@ BetaDistribution::BetaDistribution(double pos_count, double count,
                                    double p_alpha, double p_beta)
 	: _beta_distribution(p_alpha + pos_count, p_beta + count - pos_count) {}
 
+double BetaDistribution::operator()(RandGen& rng) const
+{
+	return boost::math::ibeta_inv(alpha(), beta(), rng.randdouble());
+}
+
 double BetaDistribution::alpha() const
 {
 	return _beta_distribution.alpha();

--- a/opencog/ure/BetaDistribution.h
+++ b/opencog/ure/BetaDistribution.h
@@ -25,6 +25,7 @@
 
 #include <boost/math/distributions/beta.hpp>
 
+#include <opencog/util/mt19937ar.h>
 #include <opencog/util/empty_string.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
 
@@ -47,6 +48,11 @@ public:
 	                 double prior_alpha=1.0, double prior_beta=1.0);
 	BetaDistribution(double pos_count, double count,
 	                 double prior_alpha=1.0, double prior_beta=1.0);
+
+	/**
+	 * Return a random number drawn from that beta distribution
+	 */
+	double operator()(RandGen& rng=randGen()) const;
 
 	/**
 	 * Return the alpha parameter of the distribution

--- a/opencog/ure/Rule.cc
+++ b/opencog/ure/Rule.cc
@@ -128,6 +128,14 @@ RuleSet::const_iterator RuleSet::find(const RulePtr& rule) const
 	return boost::lower_bound(*this, rule, rule_ptr_less());
 }
 
+TruthValueSeq RuleSet::get_tvs() const
+{
+	TruthValueSeq tvs;
+	for (const RulePtr& rule : *this)
+		tvs.push_back(rule->get_tv());
+	return tvs;
+}
+
 std::string RuleSet::to_string(const std::string& indent) const
 {
 	std::stringstream ss;

--- a/opencog/ure/Rule.h
+++ b/opencog/ure/Rule.h
@@ -100,6 +100,13 @@ public:
 	iterator find(const RulePtr& rule);
 	const_iterator find(const RulePtr& rule) const;
 
+	/**
+	 * Get all rule truth values, ordered according to the rules. This
+	 * can be useful to build distributions for subsequential
+	 * selection.
+	 */
+	TruthValueSeq get_tvs() const;
+
 	std::string to_string(const std::string& indent=empty_string) const;
 	std::string to_short_string(const std::string& indent=empty_string) const;
 };

--- a/opencog/ure/ThompsonSampling.cc
+++ b/opencog/ure/ThompsonSampling.cc
@@ -34,7 +34,7 @@ namespace opencog {
 ThompsonSampling::ThompsonSampling(const TruthValueSeq& tvs, unsigned bins)
 	: _tvs(tvs), _bins(bins) {}
 
-std::vector<double> ThompsonSampling::distribution()
+std::vector<double> ThompsonSampling::distribution() const
 {
 	std::vector<double> probs(_tvs.size());
 

--- a/opencog/ure/ThompsonSampling.cc
+++ b/opencog/ure/ThompsonSampling.cc
@@ -23,6 +23,9 @@
 
 #include "ThompsonSampling.h"
 
+#include <boost/range/algorithm/transform.hpp>
+#include <boost/range/algorithm/max_element.hpp>
+
 #include <opencog/util/Logger.h>
 #include <opencog/util/oc_assert.h>
 #include <opencog/util/random.h>
@@ -59,12 +62,27 @@ std::vector<double> ThompsonSampling::distribution() const
 	return probs;
 }
 
-size_t ThompsonSampling::operator()()
+size_t ThompsonSampling::operator()(RandGen& rng) const
 {
 	OC_ASSERT(not _tvs.empty());
-	std::vector<double> weights = distribution();
-	std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
-	return dist(randGen());
+
+	// Cheap trivial case
+	if (_tvs.size() == 1)
+		return 0;
+
+	// Randomly select a first order probability for each tv
+	std::vector<double> fops(_tvs.size());
+	boost::transform(_tvs, fops.begin(), [&](const auto& tv) {
+		return BetaDistribution(tv)(rng); });
+
+	// Pick up one of the maxima
+	auto it = boost::max_element(fops);
+	double max_p = *it;
+	std::set<size_t> maxima;
+	for (; it != fops.end(); ++it)
+		if (*it == max_p)
+			maxima.insert(std::distance(fops.begin(), it));
+	return *std::next(maxima.begin(), rng.randint(maxima.size()));
 }
 
 double ThompsonSampling::Pi(size_t i,

--- a/opencog/ure/ThompsonSampling.h
+++ b/opencog/ure/ThompsonSampling.h
@@ -66,7 +66,7 @@ public:
 	 * See Section Inference Rule Selection in the README.md of the
 	 * pln inference-control-learning for more explanations.
 	 */
-	std::vector<double> distribution();
+	std::vector<double> distribution() const;
 
 	/**
 	 * Perform random action selection according to the action

--- a/opencog/ure/ThompsonSampling.h
+++ b/opencog/ure/ThompsonSampling.h
@@ -23,6 +23,7 @@
 #ifndef _OPENCOG_THOMPSON_SAMPLING_H_
 #define _OPENCOG_THOMPSON_SAMPLING_H_
 
+#include <opencog/util/mt19937ar.h>
 #include <opencog/util/empty_string.h>
 #include <opencog/atoms/truthvalue/TruthValue.h>
 
@@ -52,10 +53,11 @@ public:
 	ThompsonSampling(const TruthValueSeq& tvs, unsigned bins=100);
 
 	/**
-	 * Return the index distribution, a probability for each index to
-	 * be used as sampling distribution. The distribution attempts to
-	 * reflect the optimal balance between exploration and exploitation
-	 * (Thompson sampling).
+	 * Return the index distribution (a.k.a. action distribution),
+	 * a probability for each index to be used as sampling distribution.
+	 *
+	 * The distribution attempts to reflect the optimal balance between
+	 * exploration and exploitation (Thompson sampling).
 	 *
 	 * Pi = I_0^1 pdfi(x) Prod_j!=i cdfj(x) dx / nt
 	 *
@@ -76,7 +78,7 @@ public:
 	 * select the index accordingly. This could be greatly optimized by
 	 * sampling on the fly without building it.
 	 */
-	size_t operator()();
+	size_t operator()(RandGen& rng=randGen()) const;
 
 	std::string to_string(const std::string& indent=empty_string) const;
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -453,7 +453,9 @@ SourceRule ForwardChainer::mk_source_rule(const std::string& msgprfx)
 		return mk_source_rule(msgprfx);
 	}
 
-	RulePtr slc_rule = rand_element(valid_rules);
+	// Thompson sample according to rule tvs
+	TruthValueSeq tvs = valid_rules.get_tvs();
+	RulePtr slc_rule = valid_rules[ThompsonSampling(tvs)()];
 	bool success = source->insert_rule(slc_rule);
 	if (not success)
 		return SourceRule();
@@ -591,9 +593,7 @@ RuleProbabilityPair ForwardChainer::select_rule(const RuleSet& valid_rules,
                                                 const std::string& msgprfx)
 {
 	// Build vector of all valid truth values
-	TruthValueSeq tvs;
-	for (const RulePtr& rule : valid_rules)
-		tvs.push_back(rule->get_tv());
+	TruthValueSeq tvs = valid_rules.get_tvs();
 
 	// Build action selection distribution
 	std::vector<double> weights = ThompsonSampling(tvs).distribution();


### PR DESCRIPTION
By sampling the TVs and taking the max rather than explicitly building the entire action distribution. ~100x speed up on the (source x rule) container selection on bio-atomspace experiment.