### PR TITLE
Replace production-application-ratio parameter by expansion-pool-size

### DIFF
--- a/opencog/scm/opencog/ure/ure-utils.scm
+++ b/opencog/scm/opencog/ure/ure-utils.scm
@@ -24,7 +24,7 @@
 ;; -- ure-set-maximum-iterations -- Set the URE:maximum-iterations parameter
 ;; -- ure-set-complexity-penalty -- Set the URE:complexity-penalty parameter
 ;; -- ure-set-jobs -- Set the URE:jobs parameter
-;; -- ure-set-production-application-ratio -- Set the URE:production-application-ratio parameter
+;; -- ure-set-expansion-pool-size -- Set the URE:expansion-pool-size parameter
 ;; -- ure-set-fc-retry-exhausted-sources -- Set the URE:FC:retry-exhausted-sources parameter
 ;; -- ure-set-fc-full-rule-application -- Set the URE:FC:full-rule-application parameter
 ;; -- ure-set-bc-maximum-bit-size -- Set the URE:BC:maximum-bit-size
@@ -89,7 +89,7 @@
                  (maximum-iterations *unspecified*)
                  (complexity-penalty *unspecified*)
                  (jobs *unspecified*)
-                 (production-application-ratio *unspecified*)
+                 (expansion-pool-size *unspecified*)
                  (fc-retry-exhausted-sources *unspecified*)
                  (fc-full-rule-application *unspecified*))
 "
@@ -103,7 +103,7 @@
                  #:maximum-iterations mi
                  #:complexity-penalty cp
                  #:jobs jb
-                 #:production-application-ratio par
+                 #:expansion-pool-size esp
                  #:fc-retry-exhausted-sources res
                  #:fc-full-rule-application fra)
 
@@ -133,11 +133,11 @@
 
   jb: [optional, default=1] Number of jobs to run in parallel.
 
-  par: [optional, default=1] This parameter controls how many tuples
-       -- (source, rule) for forward chainer or (inference, premise, rule)
-       for backward chainer -- are produced in average before an application
-       takes place. The higher the more tuples to choose from, which can lead
-       to better inference control.
+  esp: [optional, default=1] This parameter controls how much the
+       expension pool is supposed to grow. The larger, the more choices
+       available to select the next expansion (application in the case of
+       the forward chainer), but also then the selection is more costly.
+       Negative or null means unlimited (not recommended).
 
   res: [optional, default=#f] Whether exhausted sources should be
        retried. A source is exhausted if all its valid rules (so that at
@@ -166,8 +166,8 @@
       (ure-set-complexity-penalty rbs complexity-penalty))
   (if (not (unspecified? jobs))
       (ure-set-jobs rbs jobs))
-  (if (not (unspecified? production-application-ratio))
-      (ure-set-production-application-ratio rbs production-application-ratio))
+  (if (not (unspecified? expansion-pool-size))
+      (ure-set-expansion-pool-size rbs expansion-pool-size))
   (if (not (unspecified? fc-retry-exhausted-sources))
       (ure-set-fc-retry-exhausted-sources rbs fc-retry-exhausted-sources))
   (if (not (unspecified? fc-full-rule-application))
@@ -188,7 +188,7 @@
                  (maximum-iterations *unspecified*)
                  (complexity-penalty *unspecified*)
                  (jobs *unspecified*)
-                 (production-application-ratio *unspecified*)
+                 (expansion-pool-size *unspecified*)
                  (bc-maximum-bit-size *unspecified*)
                  (bc-mm-complexity-penalty *unspecified*)
                  (bc-mm-compressiveness *unspecified*))
@@ -204,7 +204,7 @@
                  #:maximum-iterations mi
                  #:complexity-penalty cp
                  #:jobs jb
-                 #:production-application-ratio par
+                 #:expansion-pool-size esp
                  #:bc-maximum-bit-size mbs
                  #:bc-mm-complexity-penalty mcp
                  #:bc-mm-compressiveness mc)
@@ -236,11 +236,11 @@
 
   jb: [optional, default=1] Number of jobs to run in parallel.
 
-  par: [optional, default=1] This parameter controls how many tuples
-       -- (source, rule) for forward chainer or (inference, premise, rule)
-       for backward chainer -- are produced in average before an application
-       takes place. The higher the more tuples to choose from, which can lead
-       to better inference control.
+  esp: [optional, default=1] This parameter controls how much the
+       expension pool is supposed to grow. The larger, the more choices
+       available to select the next expansion (application in the case of
+       the forward chainer), but also then the selection is more costly.
+       Negative or null means unlimited (not recommended).
 
   mbs: [optional, default=-1] Maximum size of the inference tree pool
        to evolve. Negative means unlimited.
@@ -268,8 +268,8 @@
       (ure-set-complexity-penalty rbs complexity-penalty))
   (if (not (unspecified? jobs))
       (ure-set-jobs rbs jobs))
-  (if (not (unspecified? production-application-ratio))
-      (ure-set-production-application-ratio rbs production-application-ratio))
+  (if (not (unspecified? expansion-pool-size))
+      (ure-set-expansion-pool-size rbs expansion-pool-size))
   (if (not (unspecified? bc-maximum-bit-size))
       (ure-set-bc-maximum-bit-size rbs bc-maximum-bit-size))
   (if (not (unspecified? bc-mm-complexity-penalty))
@@ -663,18 +663,18 @@
 "
   (ure-set-num-parameter rbs "URE:jobs" value))
 
-(define (ure-set-production-application-ratio rbs value)
+(define (ure-set-expansion-pool-size rbs value)
 "
-  Set the URE:production-application-ratio parameter of a given RBS
+  Set the URE:expansion-pool-size parameter of a given RBS
 
   ExecutionLink
-    SchemaNode \"URE:production-application-ratio\"
+    SchemaNode \"URE:expansion-pool-size\"
     rbs
     NumberNode value
 
   Delete any previous one if exists.
 "
-  (ure-set-num-parameter rbs "URE:production-application-ratio" value))
+  (ure-set-num-parameter rbs "URE:expansion-pool-size" value))
 
 (define (ure-set-fc-retry-exhausted-sources rbs value)
 "
@@ -1123,7 +1123,7 @@
           ure-set-maximum-iterations
           ure-set-complexity-penalty
           ure-set-jobs
-          ure-set-production-application-ratio
+          ure-set-expansion-pool-size
           ure-set-fc-retry-exhausted-sources
           ure-set-fc-full-rule-application
           ure-set-bc-maximum-bit-size

--- a/opencog/ure/UREConfig.cc
+++ b/opencog/ure/UREConfig.cc
@@ -39,8 +39,8 @@ const std::string UREConfig::complexity_penalty_name =
 	"URE:complexity-penalty";
 const std::string UREConfig::jobs_name =
 	"URE:jobs";
-const std::string UREConfig::production_application_ratio_name =
-	"URE:production-application-ratio";
+const std::string UREConfig::expansion_pool_size_name =
+	"URE:expansion-pool-size";
 const std::string UREConfig::fc_retry_exhausted_sources_name =
 	"URE:FC:retry-exhausted-sources";
 const std::string UREConfig::fc_full_rule_application_name =
@@ -88,9 +88,9 @@ int UREConfig::get_jobs() const
 	return _common_params.jobs;
 }
 
-double UREConfig::get_production_application_ratio() const
+int UREConfig::get_expansion_pool_size() const
 {
-	return _common_params.production_application_ratio;
+	return _common_params.expansion_pool_size;
 }
 
 bool UREConfig::get_retry_exhausted_sources() const
@@ -140,9 +140,9 @@ void UREConfig::set_jobs(int j)
 	_common_params.jobs = j;
 }
 
-void UREConfig::set_production_application_ratio(double par)
+void UREConfig::set_expansion_pool_size(int eps)
 {
-	_common_params.production_application_ratio = par;
+	_common_params.expansion_pool_size = eps;
 }
 
 void UREConfig::set_retry_exhausted_sources(bool rs)
@@ -207,8 +207,8 @@ void UREConfig::fetch_common_parameters(const Handle& rbs)
 	_common_params.jobs = fetch_num_param(jobs_name, rbs, 1);
 
 	// Fetch production application ratio
-	_common_params.production_application_ratio =
-		fetch_num_param(production_application_ratio_name, rbs, 1);
+	_common_params.expansion_pool_size =
+		fetch_num_param(expansion_pool_size_name, rbs, 1);
 }
 
 void UREConfig::fetch_fc_parameters(const Handle& rbs)

--- a/opencog/ure/UREConfig.h
+++ b/opencog/ure/UREConfig.h
@@ -63,7 +63,7 @@ public:
 	int get_maximum_iterations() const;
 	double get_complexity_penalty() const;
 	int get_jobs() const;
-	double get_production_application_ratio() const;
+	int get_expansion_pool_size() const;
 	// FC
 	bool get_retry_exhausted_sources() const;
 	bool get_full_rule_application() const;
@@ -84,7 +84,7 @@ public:
 	void set_maximum_iterations(int);
 	void set_complexity_penalty(double);
 	void set_jobs(int);
-	void set_production_application_ratio(double);
+	void set_expansion_pool_size(int);
 	// FC
 	void set_retry_exhausted_sources(bool);
 	void set_full_rule_application(bool);
@@ -112,7 +112,7 @@ public:
 	static const std::string jobs_name;
 
 	// Name of the production application ratio parameter
-	static const std::string production_application_ratio_name;
+	static const std::string expansion_pool_size_name;
 
 	// Name of the PredicateNode outputting whether sources should be
 	// retried after exhaustion
@@ -154,12 +154,12 @@ private:
 		// reasoning.
 		int jobs;
 
-		// This parameter controls how many tuples -- (source, rule) for
-		// forward chainer or (inference, premise, rule) for backward
-		// chainer -- are produced in average before an application
-		// takes place. The higher the more tuples to choose from, which
-		// can lead to better inference control.
-		double production_application_ratio;
+		// This parameter controls how much the expension pool is
+		// supposed to grow. The larger, the more choices available to
+		// select the next expansion (application in the case of the
+		// iterative forward chainer), but also then the selection is
+		// more costly. Negative means unlimited.
+		int expansion_pool_size;
 	};
 	CommonParameters _common_params;
 

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -473,9 +473,8 @@ void ForwardChainer::populate_source_rule_set(const std::string& msgprfx)
 {
 	LAZY_URE_LOG_DEBUG << msgprfx << "Populate the source rule set (size="
 	                   << _source_rule_set.size() << ")";
-
-	int ratio = std::max((int)_config.get_production_application_ratio(), 1);
-	for (int i = 0; i < ratio; i++) {
+	int eps = _config.get_expansion_pool_size();
+	while (eps <= 0 or (int)_source_rule_set.size() < eps) {
 		// Build (source, rule) pair for application trial
 		SourceRule sr = mk_source_rule(msgprfx);
 		if (not sr.is_valid()) {

--- a/opencog/ure/forwardchainer/SourceRuleSet.h
+++ b/opencog/ure/forwardchainer/SourceRuleSet.h
@@ -77,6 +77,8 @@ public:
  * probabilities of success into first order probabilities of action
  * via Thompson sampling ideally, or less ideally but possibly more
  * efficiently tournament selection.
+ *
+ * This container is also called the Expansion Pool.
  */
 class SourceRuleSet
 {


### PR DESCRIPTION
Otherwise, using a ratio, the expansion pool may grow indefinitely large.