### PR TITLE
Change around directory locations

### DIFF
--- a/opencog/ure/backwardchainer/BIT.cc
+++ b/opencog/ure/backwardchainer/BIT.cc
@@ -38,7 +38,7 @@
 #include <opencog/util/algorithm.h>
 #include <opencog/atoms/core/FindUtils.h>
 #include <opencog/atoms/core/TypeUtils.h>
-#include <opencog/atoms/execution/LibraryManager.h>
+#include <opencog/atoms/grounded/LibraryManager.h>
 #include <opencog/atoms/pattern/PatternUtils.h>
 
 #include "BIT.h"

--- a/opencog/ure/backwardchainer/ControlPolicy.cc
+++ b/opencog/ure/backwardchainer/ControlPolicy.cc
@@ -26,7 +26,7 @@
 #include <opencog/util/random.h>
 #include <opencog/util/algorithm.h>
 #include <opencog/unify/Unify.h>
-#include <opencog/atoms/execution/MapLink.h>
+#include <opencog/atoms/core/MapLink.h>
 
 #include "../MixtureModel.h"
 #include "../ActionSelection.h"

--- a/tests/ure/backwardchainer/GradientUTest.cxxtest
+++ b/tests/ure/backwardchainer/GradientUTest.cxxtest
@@ -24,7 +24,7 @@
 #include <opencog/util/mt19937ar.h>
 
 #include <opencog/atomspace/AtomSpace.h>
-#include <opencog/atoms/execution/LibraryManager.h>
+#include <opencog/atoms/grounded/LibraryManager.h>
 #include <opencog/atoms/truthvalue/SimpleTruthValue.h>
 #include <opencog/ure/backwardchainer/BackwardChainer.h>
 #include <opencog/ure/URELogger.h>


### PR DESCRIPTION
This is required by opencog/atomspace#2679

MapLink can now return back to it's original home, now that
the crazy Python dependency is gone.