### PR TITLE
Variable type unifier

### DIFF
--- a/opencog/unify/CMakeLists.txt
+++ b/opencog/unify/CMakeLists.txt
@@ -1,5 +1,6 @@
 ADD_LIBRARY (unify
 	Unify
+	UniVars
 )
 
 TARGET_LINK_LIBRARIES(unify
@@ -13,5 +14,6 @@ INSTALL (TARGETS unify
 
 INSTALL (FILES
 	Unify.h
+	UniVars.h
 	DESTINATION "include/opencog/unify"
 )

--- a/opencog/unify/UniVars.cc
+++ b/opencog/unify/UniVars.cc
@@ -751,7 +751,7 @@ std::string UniVars::to_string(const std::string& indent) const
 	// Simple typemap
 	std::string indent_p = indent + OC_TO_STRING_INDENT;
 	ss << indent << "_simple_typemap:" << std::endl
-	   << oc_to_string(_simple_typemap, indent_p) << std::endl;
+	   << xoc_to_string(_simple_typemap, indent_p) << std::endl;
 
 	// Glob interval map
 	ss << indent << "_glob_intervalmap:" << std::endl
@@ -759,7 +759,7 @@ std::string UniVars::to_string(const std::string& indent) const
 
 	// Deep typemap
 	ss << indent << "_deep_typemap:" << std::endl
-	   << oc_to_string(_deep_typemap, indent_p);
+	   << xoc_to_string(_deep_typemap, indent_p);
 
 	return ss.str();
 }

--- a/opencog/unify/UniVars.cc
+++ b/opencog/unify/UniVars.cc
@@ -755,22 +755,22 @@ std::string UniVars::to_string(const std::string& indent) const
 
 	// Glob interval map
 	ss << indent << "_glob_intervalmap:" << std::endl
-	   << oc_to_string(_glob_intervalmap, indent_p) << std::endl;
+	   << xoc_to_string(_glob_intervalmap, indent_p) << std::endl;
 
 	// Deep typemap
 	ss << indent << "_deep_typemap:" << std::endl
-	   << xoc_to_string(_deep_typemap, indent_p);
+	   << oc_to_string(_deep_typemap, indent_p);
 
 	return ss.str();
 }
 
-std::string oc_to_string(const UniVars& var, const std::string& indent)
+std::string opencog::oc_to_string(const UniVars& var, const std::string& indent)
 {
 	return var.to_string(indent);
 }
 
-std::string oc_to_string(const VariableSimpleTypeMap& vtm,
-                         const std::string& indent)
+std::string opencog::xoc_to_string(const VariableSimpleTypeMap& vtm,
+                                   const std::string& indent)
 {
 	std::stringstream ss;
 	ss << indent << "size = " << vtm.size();
@@ -787,7 +787,8 @@ std::string oc_to_string(const VariableSimpleTypeMap& vtm,
 	return ss.str();
 }
 
-std::string oc_to_string(const GlobIntervalMap& gim, const std::string& indent)
+std::string opencog::xoc_to_string(const GlobIntervalMap& gim,
+                                   const std::string& indent)
 {
 	std::stringstream ss;
 	ss << indent << "size = " << gim.size();

--- a/opencog/unify/UniVars.cc
+++ b/opencog/unify/UniVars.cc
@@ -1,0 +1,807 @@
+/*
+ * opencog/unify/UniVars.cc
+ *
+ * Copyright (C) 2009, 2014, 2015 Linas Vepstas
+ *               2019 SingularityNET Foundation
+ *
+ * Authors: Linas Vepstas <linasvepstas@gmail.com>  January 2009
+ *          Nil Geisweiller <ngeiswei@gmail.com> Oct 2019
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the
+ * exceptions at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/util/algorithm.h>
+#include <opencog/util/oc_assert.h>
+
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/base/Link.h>
+#include <opencog/atoms/atom_types/NameServer.h>
+
+#include <opencog/atoms/core/DefineLink.h>
+#include <opencog/atoms/core/NumberNode.h>
+#include <opencog/atoms/core/TypedVariableLink.h>
+#include <opencog/atoms/core/TypeNode.h>
+#include <opencog/atoms/core/TypeUtils.h>
+#include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/core/VariableSet.h>
+
+#include "UniVars.h"
+
+using namespace opencog;
+
+/* ================================================================= */
+
+UniVars::UniVars(bool ordered)
+	: _ordered(ordered)
+{
+}
+
+UniVars::UniVars(const Handle& vardecl, bool ordered)
+	: _ordered(ordered)
+{
+	validate_vardecl(vardecl);
+	init_index();
+}
+
+UniVars::UniVars(const HandleSeq& vardecls, bool ordered)
+	: _ordered(ordered)
+{
+	validate_vardecl(vardecls);
+	init_index();
+}
+
+/* ================================================================= */
+/**
+ * Extract the variable type(s) from a TypedVariableLink
+ */
+void UniVars::unpack_vartype(const Handle& htypelink)
+{
+	if (TYPED_VARIABLE_LINK != htypelink->get_type())
+	{
+		throw InvalidParamException(TRACE_INFO,
+			"Expecting TypedVariableLink, got %s",
+			htypelink->to_short_string().c_str());
+	}
+
+	TypedVariableLinkPtr tvlp(TypedVariableLinkCast(htypelink));
+	const Handle& varname(tvlp->get_variable());
+	_typemap.insert({varname, tvlp});
+
+	const TypeSet& ts = tvlp->get_simple_typeset();
+	if (0 < ts.size())
+		_simple_typemap.insert({varname, ts});
+
+	const HandleSet& hs = tvlp->get_deep_typeset();
+	if (0 < hs.size())
+		_deep_typemap.insert({varname, hs});
+
+	const std::pair<size_t, size_t>& gi = tvlp->get_glob_interval();
+	if (tvlp->default_interval() != gi)
+		_glob_intervalmap.insert({varname, gi});
+
+	varset.insert(varname);
+	varseq.emplace_back(varname);
+}
+
+/* ================================================================= */
+/**
+ * Validate variable declarations for syntax correctness.
+ *
+ * This will check to make sure that a set of variable declarations are
+ * of a reasonable form. Thus, for example, a structure similar to the
+ * below is expected.
+ *
+ *       VariableList
+ *          VariableNode "$var0"
+ *          VariableNode "$var1"
+ *          TypedVariableLink
+ *             VariableNode "$var2"
+ *             TypeNode  "ConceptNode"
+ *          TypedVariableLink
+ *             VariableNode "$var3"
+ *             TypeChoice
+ *                 TypeNode  "PredicateNode"
+ *                 TypeNode  "GroundedPredicateNode"
+ *
+ * As a side-effect, the variables and type restrictions are unpacked.
+ */
+void UniVars::validate_vardecl(const Handle& hdecls)
+{
+	// XXX FIXME URE calls us with broken handle!!
+	if (nullptr == hdecls) return;
+
+	// Expecting the declaration list to be either a single
+	// variable, a list or a set of variable declarations.
+	Type tdecls = hdecls->get_type();
+
+	// Order matters only if it is a list of variables
+	_ordered = VARIABLE_LIST == tdecls;
+
+	if (VARIABLE_NODE == tdecls or GLOB_NODE == tdecls)
+	{
+		varset.insert(hdecls);
+		varseq.emplace_back(hdecls);
+	}
+	else if (TYPED_VARIABLE_LINK == tdecls)
+	{
+		unpack_vartype(hdecls);
+	}
+	else if (VARIABLE_LIST == tdecls or VARIABLE_SET == tdecls)
+	{
+		// Extract the list of set of variables and make sure its as
+		// expected.
+		const HandleSeq& dset = hdecls->getOutgoingSet();
+		validate_vardecl(dset);
+	}
+	else if (UNQUOTE_LINK == tdecls)
+	{
+		// This indicates that the variable declaration is not in normal
+		// form (i.e. requires beta-reductions to be fully formed), thus
+		// variables inference is aborted for now.
+		return;
+	}
+	else if (ANCHOR_NODE == tdecls)
+	{
+		_anchor = hdecls;
+	}
+	else
+	{
+		throw InvalidParamException(TRACE_INFO,
+			"Expected a VariableList holding variable declarations");
+	}
+}
+
+bool UniVars::is_well_typed() const
+{
+	for (const auto& vt : _simple_typemap)
+		if (not opencog::is_well_typed(vt.second))
+			return false;
+	return true;
+}
+
+/* ================================================================= */
+
+/// Return true if the other UniVars struct is equal to this one,
+/// up to alpha-conversion. That is, same number of variables, same
+/// type restrictions, but possibly different variable names.
+///
+/// This should give exactly the same answer as performing the tests
+///    this->is_type(other->varseq) and other->is_type(this->varseq)
+/// That is, the variables in this instance should have the same type
+/// restrictions as the variables in the other class.
+bool UniVars::is_equal(const UniVars& other) const
+{
+	size_t sz = varseq.size();
+	if (other.varseq.size() != sz) return false;
+
+	if (other._ordered != _ordered) return false;
+
+	// Side-by-side comparison
+	for (size_t i = 0; i < sz; i++)
+	{
+		if (not is_equal(other, i))
+			return false;
+	}
+	return true;
+}
+
+bool UniVars::is_equal(const UniVars& other, size_t index) const
+{
+	const Handle& vme(varseq[index]);
+	const Handle& voth(other.varseq[index]);
+
+	// If one is a GlobNode, and the other a VariableNode,
+	// then its a mismatch.
+	if (vme->get_type() != voth->get_type()) return false;
+
+	// If typed, types must match.
+	auto sime = _typemap.find(vme);
+	auto soth = other._typemap.find(voth);
+	if (sime == _typemap.end() and
+	    soth != other._typemap.end() and
+	    not soth->second->is_untyped()) return false;
+
+	if (sime != _typemap.end())
+	{
+		if (soth == other._typemap.end() and
+		    sime->second->is_untyped()) return true;
+		if (soth == other._typemap.end()) return false;
+
+		if (not sime->second->is_equal(*soth->second)) return false;
+	}
+
+	// If we got to here, everything must be OK.
+	return true;
+}
+
+/* ================================================================= */
+
+/// Return true if the variable `othervar` in `other` is
+/// alpha-convertible to the variable `var` in this. That is,
+/// return true if they are the same variable, differing only
+/// in name.
+
+bool UniVars::is_alpha_convertible(const Handle& var,
+                                     const Handle& othervar,
+                                     const UniVars& other,
+                                     bool check_type) const
+{
+	IndexMap::const_iterator idx = other.index.find(othervar);
+	return other.index.end() != idx
+		and varseq.at(idx->second) == var
+		and (not check_type or is_equal(other, idx->second));
+}
+
+/* ================================================================= */
+/**
+ * Simple type checker.
+ *
+ * Returns true/false if the indicated handle is of the type that
+ * we have memoized.  If this typelist contains more than one type in
+ * it, then clearly, there is a mismatch.  If there are no type
+ * restrictions, then it is trivially a match.  Otherwise, there must
+ * be a TypeChoice, and so the handle must be one of the types in the
+ * TypeChoice.
+ */
+bool UniVars::is_type(const Handle& h) const
+{
+	// The arity must be one for there to be a match.
+	if (1 != varset.size()) return false;
+
+	return is_type(varseq[0], h);
+}
+
+/**
+ * Type checker.
+ *
+ * Returns true if we are holding the variable `var`, and if
+ * the `val` satisfies the type restrictions that apply to `var`.
+ */
+bool UniVars::is_type(const Handle& var, const Handle& val) const
+{
+	if (varset.end() == varset.find(var)) return false;
+
+	VariableSimpleTypeMap::const_iterator tit = _simple_typemap.find(var);
+	VariableDeepTypeMap::const_iterator dit = _deep_typemap.find(var);
+
+	const Arity num_args = val->get_type() != LIST_LINK ? 1 : val->get_arity();
+
+	// If one is allowed in interval then there are two alternatives.
+	// one: val must satisfy type restriction.
+	// two: val must be list_link and its unique outgoing satisfies
+	//      type restriction.
+	if (is_lower_bound(var, 1) and is_upper_bound(var, 1)
+	    and is_type(tit, dit, val))
+		return true;
+	else if (val->get_type() != LIST_LINK or
+	         not is_lower_bound(var, num_args) or
+	         not is_upper_bound(var, num_args))
+		// If the number of arguments is out of the allowed interval
+		// of the variable/glob or val is not List_link, return false.
+		return false;
+
+	// Every outgoing atom in list must satisfy type restriction of var.
+	for (size_t i = 0; i < num_args; i++)
+		if (!is_type(tit, dit, val->getOutgoingAtom(i)))
+			return false;
+
+	return true;
+}
+
+bool UniVars::is_type(VariableSimpleTypeMap::const_iterator tit,
+                        VariableDeepTypeMap::const_iterator dit,
+                        const Handle& val) const
+{
+	bool ret = true;
+
+	// Simple type restrictions?
+	if (_simple_typemap.end() != tit)
+	{
+		const TypeSet &tchoice = tit->second;
+		Type htype = val->get_type();
+		TypeSet::const_iterator allow = tchoice.find(htype);
+
+		// If the argument has the simple type, then we are good to go;
+		// we are done.  Else, fall through, and see if one of the
+		// others accept the match.
+		if (allow != tchoice.end()) return true;
+		ret = false;
+	}
+
+	// Deep type restrictions?
+	if (_deep_typemap.end() != dit)
+	{
+		const HandleSet &sigset = dit->second;
+		for (const Handle& sig : sigset)
+		{
+			if (value_is_type(sig, val)) return true;
+		}
+		ret = false;
+	}
+
+	// There appear to be no type restrictions...
+	return ret;
+}
+
+/**
+ * Return true if we contain just a single variable, and this one
+ * variable is of type gtype (or is untyped). A typical use is that
+ * gtype==VARIABLE_LIST.
+ */
+bool UniVars::is_type(Type gtype) const
+{
+	if (1 != varseq.size()) return false;
+
+	// Are there any type restrictions?
+	const Handle& var = varseq[0];
+	VariableTypeMap::const_iterator tit = _typemap.find(var);
+	if (_typemap.end() == tit) return true;
+
+	// There are type restrictions; do they match?
+	return tit->second->is_type(gtype);
+}
+
+/**
+ * Simple type checker.
+ *
+ * Returns true/false if the indicated handles are of the type that
+ * we have memoized.
+ *
+ * XXX TODO this does not currently handle type equations, as outlined
+ * on the wiki; We would need the general pattern matcher to do type
+ * checking, in that situation.
+ */
+bool UniVars::is_type(const HandleSeq& hseq) const
+{
+	// The arities must be equal for there to be a match.
+	size_t len = hseq.size();
+	if (varset.size() != len) return false;
+
+	// Check the type restrictions.
+	for (size_t i=0; i<len; i++)
+	{
+		if (not is_type(varseq[i], hseq[i])) return false;
+	}
+	return true;
+}
+
+/* ================================================================= */
+/**
+ * Interval checker.
+ *
+ * Returns true if the glob satisfies the lower bound
+ * interval restriction.
+ */
+bool UniVars::is_lower_bound(const Handle& glob, size_t n) const
+{
+	const GlobInterval &intervals = get_interval(glob);
+	return (n >= intervals.first);
+}
+
+/**
+ * Interval checker.
+ *
+ * Returns true if the glob satisfies the upper bound
+ * interval restriction.
+ */
+bool UniVars::is_upper_bound(const Handle &glob, size_t n) const
+{
+	const GlobInterval &intervals = get_interval(glob);
+	return (n <= intervals.second or intervals.second < 0);
+}
+
+/**
+ * Interval checker.
+ *
+ * Returns true if the glob can match a variable number of items.
+ * i.e. if it is NOT an ordinary variable.
+ */
+bool UniVars::is_globby(const Handle &glob) const
+{
+	const GlobInterval &intervals = get_interval(glob);
+	return (1 != intervals.first or 1 != intervals.second);
+}
+
+static const GlobInterval& default_interval(Type t)
+{
+	static const GlobInterval var_def_interval =
+			GlobInterval(1, 1);
+	static const GlobInterval glob_def_interval =
+			GlobInterval(1, SIZE_MAX);
+	return t == GLOB_NODE ? glob_def_interval :
+			 var_def_interval;
+}
+
+const GlobInterval& UniVars::get_interval(const Handle& var) const
+{
+	const auto& interval = _glob_intervalmap.find(var);
+
+	if (interval == _glob_intervalmap.end())
+		return default_interval(var->get_type());
+
+	return interval->second;
+}
+
+/* ================================================================= */
+/**
+ * Substitute the given arguments for the variables occuring in a tree.
+ * That is, perform beta-reduction.  This is a lot like applying the
+ * function `func` to the argument list `args`, except that no actual
+ * evaluation is performed; only substitution.
+ *
+ * The resulting tree is NOT placed into any atomspace. If you want
+ * that, you must do it yourself.  If you want evaluation or execution
+ * to happen during substitution, then use either the EvaluationLink,
+ * the ExecutionOutputLink, or the Instantiator.
+ *
+ * So, for example, if this VariableList contains:
+ *
+ *   VariableList
+ *       VariableNode $a
+ *       VariableNode $b
+ *
+ * and `func` is the template:
+ *
+ *   EvaluationLink
+ *      PredicateNode "something"
+ *      ListLink
+ *         VariableNode $b      ; note the reversed order
+ *         VariableNode $a
+ *
+ * and the `args` is a list
+ *
+ *      ConceptNode "one"
+ *      NumberNode 2.0000
+ *
+ * then the returned result will be
+ *
+ *   EvaluationLink
+ *      PredicateNode "something"
+ *      ListLink
+ *          NumberNode 2.0000    ; note reversed order here, also
+ *          ConceptNode "one"
+ *
+ * That is, the arguments `one` and `2.0` were substituted for `$a` and `$b`.
+ *
+ * The `func` can be, for example, a single variable name(!) In this
+ * case, the corresponding `arg` is returned. So, for example, if the
+ * `func` was simply `$b`, then `2.0` would be returned.
+ *
+ * Type checking is performed before substitution; if the args fail to
+ * satisfy the type constraints, an exception is thrown. If `silent`
+ * is true, then the exception is non-printing, and so this method can
+ * be used for "filtering", i.e. for automatically rejecting arguments
+ * that fail the type check.
+ *
+ * The substitution is almost purely syntactic... with one exception:
+ * the semantics of QuoteLink and UnquoteLink are honoured.  That is,
+ * no variable reduction is performed into any part of the tree which
+ * is quoted. (QuoteLink is like scheme's quasi-quote, in that each
+ * UnquoteLink undoes one level of quotation.)
+ *
+ * Again, only a substitution is performed, there is no evaluation.
+ * Note also that the resulting tree is NOT placed into any atomspace!
+ */
+Handle UniVars::substitute(const Handle& func,
+                             const HandleSeq& args,
+                             bool silent) const
+{
+	if (args.size() != varseq.size())
+		throw SyntaxException(TRACE_INFO,
+			"Incorrect number of arguments specified, expecting %lu got %lu",
+			varseq.size(), args.size());
+
+	// XXX TODO type-checking could be lazy; if the function is not
+	// actually using one of the args, it's type should not be checked.
+	// Viz., one of the arguments might be undefined, and that's OK,
+	// if that argument is never actually used.  Fixing this requires a
+	// cut-n-paste of the substitute_nocheck code. I'm too lazy to do
+	// this ... no one wants this whizzy-ness just right yet.
+	if (not is_type(args))
+	{
+		if (silent) throw TypeCheckException();
+		throw SyntaxException(TRACE_INFO,
+			"Arguments fail to match variable declarations");
+	}
+
+	return substitute_nocheck(func, args);
+}
+
+Handle UniVars::substitute(const Handle& func,
+                             const HandleMap& map,
+                             bool silent) const
+{
+	return substitute(func, make_sequence(map), silent);
+}
+
+/* ================================================================= */
+/**
+ * Extend a set of variables.
+ *
+ * That is, merge the given variables into this set.
+ *
+ * If a variable is both in *this and vset then its type intersection
+ * is assigned to it.
+ */
+void UniVars::extend(const UniVars& vset)
+{
+	for (const Handle& h : vset.varseq)
+	{
+		auto index_it = index.find(h);
+		if (index_it != index.end())
+		{
+			// Merge the two typemaps, if needed.
+			auto stypemap_it = vset._simple_typemap.find(h);
+			if (stypemap_it != vset._simple_typemap.end())
+			{
+				const TypeSet& tms = stypemap_it->second;
+				auto tti = _simple_typemap.find(h);
+				if(tti != _simple_typemap.end())
+					tti->second = set_intersection(tti->second, tms);
+				else
+					_simple_typemap.insert({h, tms});
+			}
+		}
+		else
+		{
+			// Found a new variable! Insert it.
+			index.insert({h, varseq.size()});
+
+			auto typemap_it = vset._typemap.find(h);
+			if (typemap_it != vset._typemap.end())
+				unpack_vartype(HandleCast(typemap_it->second));
+			else
+			{
+				varseq.emplace_back(h);
+				varset.insert(h);
+			}
+		}
+		// extend _glob_interval_map
+		extend_interval(h, vset);
+	}
+
+	// If either this or the other are ordered then the result is ordered
+	_ordered = _ordered or vset._ordered;
+}
+
+inline GlobInterval interval_intersection(const GlobInterval &lhs,
+                                          const GlobInterval &rhs)
+{
+	const auto lb = std::max(lhs.first, rhs.first);
+	const auto ub = std::min(lhs.second, rhs.second);
+	return lb > ub ? GlobInterval{0, 0} : GlobInterval{lb, ub};
+}
+
+void UniVars::extend_interval(const Handle &h, const UniVars &vset)
+{
+	auto it = _glob_intervalmap.find(h);
+	auto is_in_gim = it != _glob_intervalmap.end();
+	const auto intersection = not is_in_gim ? vset.get_interval(h) :
+			interval_intersection(vset.get_interval(h), get_interval(h));
+	if (intersection != default_interval(h->get_type())) {
+		if (is_in_gim) it->second = intersection;
+		else _glob_intervalmap.insert({h, intersection});
+	}
+}
+
+void UniVars::erase(const Handle& var)
+{
+	// Remove from the type maps
+	_typemap.erase(var);
+	_simple_typemap.erase(var);
+	_deep_typemap.erase(var);
+
+	// Remove from the interval map
+	_glob_intervalmap.erase(var);
+
+	// Remove FreeVariables
+	FreeVariables::erase(var);
+}
+
+bool UniVars::operator==(const UniVars& other) const
+{
+	return is_equal(other);
+}
+
+bool UniVars::operator<(const UniVars& other) const
+{
+	return FreeVariables::operator<(other)
+		or (_simple_typemap == other._simple_typemap
+		     and _deep_typemap < other._deep_typemap);
+}
+
+/// Look up the type declaration for `var`, but create the actual
+/// declaration for `alt`.  This is an alpha-renaming.
+Handle UniVars::get_type_decl(const Handle& var, const Handle& alt) const
+{
+	HandleSeq types;
+
+	// Simple type info
+	const auto& sit = _simple_typemap.find(var);
+	if (sit != _simple_typemap.end())
+	{
+		for (Type t : sit->second)
+			types.push_back(Handle(createTypeNode(t)));
+	}
+
+	const auto& dit = _deep_typemap.find(var);
+	if (dit != _deep_typemap.end())
+	{
+		for (const Handle& sig: dit->second)
+			types.push_back(sig);
+	}
+
+	// Check if ill-typed a.k.a invalid type intersection.
+	if (types.empty() and sit != _simple_typemap.end())
+	{
+		const Handle ill_type = createLink(TYPE_CHOICE);
+		return createLink(TYPED_VARIABLE_LINK, alt, ill_type);
+	}
+
+	const auto interval = get_interval(var);
+	if (interval != default_interval(var->get_type()))
+	{
+		Handle il = createLink(INTERVAL_LINK,
+		                       Handle(createNumberNode(interval.first)),
+		                       Handle(createNumberNode(interval.second)));
+
+		if (types.empty())
+			return createLink(TYPED_VARIABLE_LINK, alt, il);
+
+		HandleSeq tcs;
+		for (Handle tn : types)
+			tcs.push_back(createLink(TYPE_SET_LINK, il, tn));
+		return tcs.size() == 1 ?
+		       createLink(TYPED_VARIABLE_LINK, alt, tcs[0]) :
+		       createLink(TYPED_VARIABLE_LINK, alt,
+		                  createLink(tcs, TYPE_CHOICE));
+	}
+
+	// No/Default interval found
+	if (not types.empty())
+	{
+		Handle types_h = types.size() == 1 ?
+		                 types[0] :
+		                 createLink(std::move(types), TYPE_CHOICE);
+		return createLink(TYPED_VARIABLE_LINK, alt, types_h);
+	}
+
+	// No type info
+	return alt;
+}
+
+Handle UniVars::get_vardecl() const
+{
+	HandleSeq vardecls;
+	for (const Handle& var : varseq)
+		vardecls.emplace_back(get_type_decl(var, var));
+	if (vardecls.size() == 1)
+		return vardecls[0];
+
+	if (_ordered)
+		return Handle(createVariableList(std::move(vardecls)));
+
+	return Handle(createVariableSet(std::move(vardecls)));
+}
+
+void UniVars::validate_vardecl(const HandleSeq& oset)
+{
+	for (const Handle& h: oset)
+	{
+		Type t = h->get_type();
+		if (VARIABLE_NODE == t or GLOB_NODE == t)
+		{
+			varset.insert(h);
+			varseq.emplace_back(h);
+		}
+		else if (TYPED_VARIABLE_LINK == t)
+		{
+			unpack_vartype(h);
+		}
+		else if (ANCHOR_NODE == t)
+		{
+			_anchor = h;
+		}
+		else
+		{
+			throw InvalidParamException(TRACE_INFO,
+				"Expected a Variable or TypedVariable or Anchor, got: %s"
+				"\nVariableList is %s",
+					nameserver().getTypeName(t).c_str(),
+					to_string().c_str());
+		}
+	}
+}
+
+void UniVars::find_variables(const Handle& body)
+{
+	FreeVariables::find_variables(body);
+	_ordered = false;
+}
+
+void UniVars::find_variables(const HandleSeq& oset, bool ordered_link)
+{
+	FreeVariables::find_variables(oset, ordered_link);
+	_ordered = false;
+}
+
+std::string UniVars::to_string(const std::string& indent) const
+{
+	std::stringstream ss;
+
+	// FreeVariables
+	ss << FreeVariables::to_string(indent) << std::endl;
+
+	// Whether it is ordered
+	ss << indent << "_ordered = " << _ordered << std::endl;
+
+	// Simple typemap
+	std::string indent_p = indent + OC_TO_STRING_INDENT;
+	ss << indent << "_simple_typemap:" << std::endl
+	   << oc_to_string(_simple_typemap, indent_p) << std::endl;
+
+	// Glob interval map
+	ss << indent << "_glob_intervalmap:" << std::endl
+	   << oc_to_string(_glob_intervalmap, indent_p) << std::endl;
+
+	// Deep typemap
+	ss << indent << "_deep_typemap:" << std::endl
+	   << oc_to_string(_deep_typemap, indent_p);
+
+	return ss.str();
+}
+
+std::string oc_to_string(const UniVars& var, const std::string& indent)
+{
+	return var.to_string(indent);
+}
+
+std::string oc_to_string(const VariableSimpleTypeMap& vtm,
+                         const std::string& indent)
+{
+	std::stringstream ss;
+	ss << indent << "size = " << vtm.size();
+	unsigned i = 0;
+	for (const auto& v : vtm)
+	{
+		ss << std::endl << indent << "variable[" << i << "]:" << std::endl
+		   << oc_to_string(v.first, indent + OC_TO_STRING_INDENT) << std::endl
+		   << indent << "types[" << i << "]:";
+		for (auto& t : v.second)
+			ss << " " << nameserver().getTypeName(t);
+		i++;
+	}
+	return ss.str();
+}
+
+std::string oc_to_string(const GlobIntervalMap& gim, const std::string& indent)
+{
+	std::stringstream ss;
+	ss << indent << "size = " << gim.size();
+	unsigned i = 0;
+	for (const auto& v : gim)
+	{
+		ss << std::endl << indent << "glob[" << i << "]:" << std::endl
+		   << oc_to_string(v.first, indent + OC_TO_STRING_INDENT) << std::endl
+		   << indent << "interval[" << i << "]: ";
+		double lo = v.second.first;
+		double up = v.second.second;
+		ss << ((0 <= lo and std::isfinite(lo)) ? "[" : "(") << lo << ", "
+		   << up << ((0 <= up and std::isfinite(up)) ? "]" : ")");
+		i++;
+	}
+	return ss.str();
+}

--- a/opencog/unify/UniVars.h
+++ b/opencog/unify/UniVars.h
@@ -1,0 +1,215 @@
+/*
+ * opencog/unify/UniVars.h
+ *
+ * Copyright (C) 2015 Linas Vepstas
+ * All Rights Reserved
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENCOG_UNIVARS_H
+#define _OPENCOG_UNIVARS_H
+
+#include <map>
+#include <set>
+
+#include <opencog/util/empty_string.h>
+#include <opencog/atoms/base/Handle.h>
+#include <opencog/atoms/base/Atom.h>
+#include <opencog/atoms/core/FreeVariables.h>
+#include <opencog/atoms/core/TypedVariableLink.h>
+
+namespace opencog
+{
+/** \addtogroup grp_atomspace
+ *  @{
+ */
+
+typedef std::map<Handle, TypedVariableLinkPtr> VariableTypeMap;
+typedef std::map<Handle, TypeSet> VariableSimpleTypeMap;
+typedef std::map<Handle, HandleSet> VariableDeepTypeMap;
+typedef std::pair<size_t, size_t> GlobInterval;
+typedef std::map<Handle, GlobInterval> GlobIntervalMap;
+
+/// The UniVars struct defines a list of typed variables "unbundled"
+/// from the hypergraph in which they normally occur. The goal of this
+/// structure is to unify Variable types declarations.
+///
+struct UniVars : public FreeVariables
+{
+	// CTors. The ordered flag indicates whether we care about the
+	// order of the variables. It is false by default and only enabled
+	// if VariableList is used.
+	UniVars(bool ordered=false);
+	UniVars(const Handle& vardecl, bool ordered=false);
+	UniVars(const HandleSeq& vardecls, bool ordered=false);
+
+	/// Whether the order matters or not. Typically if constructed with
+	/// VariableList then the order matters, if constructed with
+	/// VariableSet then the order does not matter.
+	bool _ordered;
+
+	/// Unbundled variables and type restrictions for them.
+
+	/// _typemap holds back-ponters to TypedVariableLinkPtrs
+	/// _simple_typemap is the (possibly empty) list of restrictions
+	/// on the variable types. It holds a disjunction of class Type.
+	/// _deep_typemap holds complex or "deep" type definitions, such
+	/// as those defined by SignatureLink.
+	VariableTypeMap _typemap;
+	VariableSimpleTypeMap _simple_typemap;
+	VariableDeepTypeMap _deep_typemap;
+
+	/// To restrict how many atoms should be matched for each of the
+	/// GlobNodes in the pattern.
+	GlobIntervalMap _glob_intervalmap;
+
+	/// Anchor, if present, else undefined.
+	Handle _anchor;
+
+	// Validate the variable decls
+	void validate_vardecl(const Handle&);
+	void validate_vardecl(const HandleSeq&);
+	void unpack_vartype(const Handle&);
+
+	/// Return true iff all variables are well typed. For now only
+	/// simple types are supported, specifically if some variable is
+	/// simple typed NOTYPE, then it returns false.
+	bool is_well_typed() const;
+
+	// Return true if the other UniVars struct is equal to this one,
+	// up to alpha-conversion. That is, same number of variables, same
+	// type restrictions, but different actual variable names.
+	// Same as satisfying this->is_type(other->varseq) and also
+	// other->is_type(this->varseq) -- the equality is symmetric.
+	bool is_equal(const UniVars& other) const;
+	bool is_equal(const UniVars& other, size_t index) const;
+	bool operator==(const UniVars& other) const;
+
+	// Comparison operators. Convenient to define containers of UniVars
+	bool operator<(const UniVars& other) const;
+
+	// Return true if the variable `othervar` in `other` is
+	// alpha-convertible to the variable `var` in this. That is,
+	// return true if they are the same variable, differing only
+	// in name.
+	bool is_alpha_convertible(const Handle& var,
+	                          const Handle& othervar,
+	                          const UniVars& other,
+	                          bool check_type=false) const;
+
+	// Return true if we are holding a single variable, and the handle
+	// given as the argument satisfies the type restrictions (if any).
+	// Else return false.
+	bool is_type(const Handle&) const;
+
+	// Return true if we are holding a single variable, and it can
+	// be the indicated type.
+	bool is_type(Type) const;
+
+	// Return true if we are holding the variable `var`, and `val`
+	// satisfies the type restrictions that apply to `var`.
+	bool is_type(const Handle& var, const Handle& val) const;
+
+	// Return true if the sequence is of the same length as the variable
+	// declarations we are holding, and if they satisfy all of the type
+	// restrictions (if any).
+	bool is_type(const HandleSeq& hseq) const;
+
+	// Return true if the int satisfies the lower bound interval restriction.
+	// Return false otherwise.
+	bool is_lower_bound(const Handle& glob, size_t n) const;
+
+	// Return true if the int satisfies the upper bound interval restriction.
+	// Return false otherwise.
+	bool is_upper_bound(const Handle& glob, size_t n) const;
+
+	// Return true if the variable is has a range other than
+	// (1,1) i.e. if it can match more than one thing.
+	bool is_globby(const Handle& glob) const;
+
+	// Given the tree `tree` containing variables in it, create and
+	// return a new tree with the indicated arguments `args` substituted
+	// for the variables. The `args` must pass the typecheck, else an
+	// exception is thrown. If "silent" is true, then the exception
+	// will not be logged; this allows this method to be used for
+	// filtering, where type mis-checks are expected and normal.
+	Handle substitute(const Handle& tree,
+	                  const HandleSeq& args,
+	                  bool silent=false) const;
+
+	// Like the above, but using a partial map.
+	Handle substitute(const Handle& tree,
+	                  const HandleMap& map,
+	                  bool silent=false) const;
+
+	// Extend this by adding in the given variables. If either this or
+	// the other are ordered, then the result is ordered
+	void extend(const UniVars&);
+
+	// Erase the given variable, if exist
+	void erase(const Handle&);
+
+	/// Return the TypedVariableLink for the indicated variable.
+	/// Return just the Variable itself, if its not typed.
+	Handle get_type_decl(const Handle&, const Handle&) const;
+
+	/// Inverse of UniVars(vardecl).get_variable()
+	///
+	/// That is, convert UniVars object into a variable declaration,
+	/// that is a VariableList, VariableSet, TypedVariableLink,
+	/// VariableNode or GlobNode, suitable for direct use in a
+	/// ScopeLink.
+	///
+	/// If empty then return the empty VariableList or VariableSet.
+	Handle get_vardecl() const;
+
+	/// Like FreeUniVars::find_variables but set _ordered to false,
+	/// on the ground that if this method is called, then no order
+	/// was intended in the variable scope.
+	void find_variables(const Handle& body);
+	void find_variables(const HandleSeq& oset, bool ordered_link=true);
+
+	const GlobInterval& get_interval(const Handle&) const;
+
+	// Useful for debugging
+	std::string to_string(const std::string& indent=empty_string) const;
+
+protected:
+
+	bool is_type(VariableSimpleTypeMap::const_iterator,
+	             VariableDeepTypeMap::const_iterator,
+	             const Handle&) const;
+
+	void extend_interval(const Handle &h, const UniVars &vset);
+};
+
+// Debugging helpers see
+// http://wiki.opencog.org/w/Development_standards#Print_OpenCog_Objects
+// The reason indent is not an optional argument with default is
+// because gdb doesn't support that, see
+// http://stackoverflow.com/questions/16734783 for more explanation.
+std::string xoc_to_string(const VariableSimpleTypeMap& vtm,
+                         const std::string& indent=empty_string);
+std::string xoc_to_string(const GlobIntervalMap& gim,
+                         const std::string& indent=empty_string);
+std::string oc_to_string(const UniVars& var,
+                         const std::string& indent=empty_string);
+
+/** @}*/
+}
+
+#endif // _OPENCOG_UNIVARS_H

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -250,9 +250,11 @@ Unify::TypedSubstitution Unify::typed_substitution(const Partition& partition,
 	// Remove ill quotations
 	Variables tmpv(_variables.get_vardecl());
 	for (auto& vcv : var2cval) {
+		bool needless_quotation = true;
 		Handle consumed =
 			RewriteLink::consume_quotations(tmpv, vcv.second.handle,
-			                                vcv.second.context.quotation, false);
+			                                vcv.second.context.quotation,
+			                                needless_quotation, false);
 		vcv.second = CHandle(consumed, vcv.second.context);
 	}
 
@@ -466,7 +468,10 @@ Handle Unify::substitute(BindLinkPtr bl, const HandleMap& var2val,
 	// Perform substitution over the pattern term, then remove
 	// constant clauses
 	Handle clauses = variables.substitute_nocheck(bl->get_body(), values);
-	clauses = RewriteLink::consume_quotations(vardecl, clauses, true);
+	Variables tmpv(vardecl);
+	bool needless_quotation = true;
+	clauses = RewriteLink::consume_quotations(tmpv, clauses,
+                             Quotation(), needless_quotation, true);
 	if (queried_as)
 		clauses = remove_constant_clauses(vardecl, clauses, queried_as);
 	hs.push_back(clauses);
@@ -475,7 +480,10 @@ Handle Unify::substitute(BindLinkPtr bl, const HandleMap& var2val,
 	for (const Handle& himp: bl->get_implicand())
 	{
 		Handle rewrite = variables.substitute_nocheck(himp, values);
-		rewrite = RewriteLink::consume_quotations(vardecl, rewrite, false);
+		Variables tmpv(vardecl);
+		bool needless_quotation = true;
+		rewrite = RewriteLink::consume_quotations(tmpv, rewrite,
+		                      Quotation(), needless_quotation, false);
 		hs.push_back(rewrite);
 	}
 

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -434,6 +434,12 @@ Handle Unify::substitute(BindLinkPtr bl, const TypedSubstitution& ts,
 	return substitute(bl, strip_context(ts.first), ts.second, queried_as);
 }
 
+static Handle make_vardecl(const Handle& h)
+{
+	HandleSet vars = get_free_variables(h);
+	return Handle(createVariableSet(HandleSeq(vars.begin(), vars.end())));
+}
+
 Handle Unify::substitute(BindLinkPtr bl, const HandleMap& var2val,
                          Handle vardecl, const AtomSpace* queried_as)
 {
@@ -443,7 +449,7 @@ Handle Unify::substitute(BindLinkPtr bl, const HandleMap& var2val,
 		// If the bind link has no variable declaration either then
 		// infer one
 		Handle old_vardecl = bl->get_vardecl() ? bl->get_vardecl()
-			: gen_vardecl(bl->get_body());
+			: make_vardecl(bl->get_body());
 		// Substitute the variables in the old vardecl to obtain the
 		// new one.
 		vardecl = substitute_vardecl(old_vardecl, var2val);

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -193,6 +193,26 @@ Unify::Unify(const Handle& lhs, const Handle& rhs,
 	_variables = merge_variables(lhs_vars, rhs_vars);
 }
 
+Unify::Unify(const Handle& lhs, const Handle& rhs,
+             const Variables& lhs_vars, const Variables& rhs_vars)
+{
+	// Set terms to unify
+	_lhs = lhs;
+	_rhs = rhs;
+
+	// UniVars lhs_uv(lhs_vars.varseq);
+	UniVars lhs_uv;
+	for (const auto& vtype : lhs_vars._typemap)
+		lhs_uv.unpack_vartype(HandleCast(vtype.second));
+
+	UniVars rhs_uv;
+	for (const auto& vtype : rhs_vars._typemap)
+		rhs_uv.unpack_vartype(HandleCast(vtype.second));
+
+	// Set _variables
+	_variables = merge_variables(lhs_uv, rhs_uv);
+}
+
 Unify::TypedSubstitutions Unify::typed_substitutions(const SolutionSet& sol,
                                                      const Handle& pre) const
 {

--- a/opencog/unify/Unify.cc
+++ b/opencog/unify/Unify.cc
@@ -200,7 +200,7 @@ Unify::Unify(const Handle& lhs, const Handle& rhs,
 	_lhs = lhs;
 	_rhs = rhs;
 
-	// UniVars lhs_uv(lhs_vars.varseq);
+#if COPY_TYPE_CONSTRAINTS
 	UniVars lhs_uv;
 	for (const auto& vtype : lhs_vars._typemap)
 		lhs_uv.unpack_vartype(HandleCast(vtype.second));
@@ -208,6 +208,11 @@ Unify::Unify(const Handle& lhs, const Handle& rhs,
 	UniVars rhs_uv;
 	for (const auto& vtype : rhs_vars._typemap)
 		rhs_uv.unpack_vartype(HandleCast(vtype.second));
+#endif
+
+	// Ignore the type constraints that might be present
+	UniVars lhs_uv(lhs_vars.varseq);
+	UniVars rhs_uv(rhs_vars.varseq);
 
 	// Set _variables
 	_variables = merge_variables(lhs_uv, rhs_uv);

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -869,12 +869,6 @@ bool tss_content_eq(const Unify::TypedSubstitutions& lhs,
 HandleMap strip_context(const Unify::HandleCHandleMap& hchm);
 
 /**
- * Generate a VariableList of the free variables of a given contextual
- * atom ch.
- */
-VariableListPtr gen_varlist(const Unify::CHandle& ch);
-
-/**
  * Merge two vardecls into one. If a variable is present in both
  * vardecls then the more restrictive one replaces the less
  * restrictive one.

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -33,6 +33,7 @@
 #include <opencog/atoms/base/Handle.h>
 #include <opencog/atoms/core/Context.h>
 #include <opencog/atoms/core/VariableList.h>
+#include <opencog/atoms/core/Variables.h>
 #include <opencog/atoms/pattern/BindLink.h>
 #include <opencog/unify/UniVars.h>
 
@@ -199,6 +200,8 @@ public:
 	      const Handle& rhs_vardecl=Handle::UNDEFINED);
 	Unify(const Handle& lhs, const Handle& rhs,
 	      const UniVars& lhs_vars, const UniVars& rhs_vars);
+	Unify(const Handle& lhs, const Handle& rhs,
+	      const Variables& lhs_vars, const Variables& rhs_vars);
 
 	/**
 	 * Generate typed substitution rules, given a satisfiable

--- a/opencog/unify/Unify.h
+++ b/opencog/unify/Unify.h
@@ -34,6 +34,7 @@
 #include <opencog/atoms/core/Context.h>
 #include <opencog/atoms/core/VariableList.h>
 #include <opencog/atoms/pattern/BindLink.h>
+#include <opencog/unify/UniVars.h>
 
 namespace opencog {
 
@@ -185,7 +186,7 @@ public:
 	// after substitution (cause some values may be variables).
 	//
 	// TODO: maybe we could simplify a great deal of code by replacing
-	// Handle by Variables.
+	// Handle by UniVars.
 	typedef std::map<HandleCHandleMap, Handle> TypedSubstitutions;
 	typedef std::pair<HandleCHandleMap, Handle> TypedSubstitution;
 
@@ -197,7 +198,7 @@ public:
 	      const Handle& lhs_vardecl=Handle::UNDEFINED,
 	      const Handle& rhs_vardecl=Handle::UNDEFINED);
 	Unify(const Handle& lhs, const Handle& rhs,
-	      const Variables& lhs_vars, const Variables& rhs_vars);
+	      const UniVars& lhs_vars, const UniVars& rhs_vars);
 
 	/**
 	 * Generate typed substitution rules, given a satisfiable
@@ -514,7 +515,7 @@ private:
 	Handle _rhs;
 
 	// Common variable declaration of the two terms to unify.
-	Variables _variables;
+	UniVars _variables;
 
 public:                         // ???? It's a friend yet
 	/**
@@ -877,7 +878,7 @@ VariableListPtr gen_varlist(const Unify::CHandle& ch);
  *
  * TODO: give example.
  */
-Variables merge_variables(const Variables& lv, const Variables& rv);
+UniVars merge_variables(const UniVars& lv, const UniVars& rv);
 Handle merge_vardecl(const Handle& l_vardecl, const Handle& r_vardecl);
 
 // Debugging helpers see

--- a/opencog/ure/backwardchainer/BIT.cc
+++ b/opencog/ure/backwardchainer/BIT.cc
@@ -93,8 +93,14 @@ AndBIT::AndBIT(AtomSpace& bit_as, const Handle& target, Handle vardecl,
                const BITNodeFitness& fitness, const AtomSpace* qas)
 	: exhausted(false), queried_as(qas)
 {
+	// in case it is undefined
+	if (nullptr == vardecl)
+	{
+		HandleSet vars = get_free_variables(target);
+		vardecl = HandleCast(createVariableSet(HandleSeq(vars.begin(), vars.end())));
+	}
+
 	// Create initial FCS
-	vardecl = gen_vardecl(target, vardecl); // in case it is undefined
 	Handle body =
 		Unify::remove_constant_clauses(vardecl, target, queried_as);
 	HandleSeq bl{body, target};

--- a/tests/unify/CMakeLists.txt
+++ b/tests/unify/CMakeLists.txt
@@ -9,3 +9,4 @@ ENDIF (HAVE_GUILE)
 
 ADD_CXXTEST(UnifyUTest)
 ADD_CXXTEST(UnifyGlobUTest)
+ADD_CXXTEST(UniVarsUTest)

--- a/tests/unify/UniVarsUTest.cxxtest
+++ b/tests/unify/UniVarsUTest.cxxtest
@@ -1,5 +1,5 @@
 /*
- * tests/atoms/core/VariablesUTest.cxxtest
+ * tests/atoms/core/UniVarsUTest.cxxtest
  *
  * Copyright (C) 2016 OpenCog Foundation
  * All Rights Reserved
@@ -21,8 +21,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <opencog/atoms/core/Variables.h>
-#include <opencog/atoms/core/VariableList.h>
+#include <opencog/unify/UniVars.h>
 #include <opencog/atomspace/AtomSpace.h>
 
 #include <cxxtest/TestSuite.h>
@@ -32,7 +31,7 @@ using namespace opencog;
 #define al _as.add_link
 #define an _as.add_node
 
-class VariablesUTest : public CxxTest::TestSuite
+class UniVarsUTest : public CxxTest::TestSuite
 {
 private:
 	Handle A, B, W, X, Y, Z, G1, G2, NT, PNT, CNT, NTI, DPTCI, LLT, LTI;
@@ -40,7 +39,7 @@ private:
 	AtomSpace _as;
 
 public:
-	VariablesUTest()
+	UniVarsUTest()
 	{
 		logger().set_level(Logger::DEBUG);
 		logger().set_timestamp_flag(false);
@@ -99,7 +98,7 @@ public:
 	void test_substitute_nocheck_scope();
 };
 
-void VariablesUTest::test_extend_1()
+void UniVarsUTest::test_extend_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -112,9 +111,7 @@ void VariablesUTest::test_extend_1()
 		            al(TYPED_VARIABLE_LINK, X, PNT),
 		            al(TYPED_VARIABLE_LINK, Y, CNT));
 
-	VariableList vl1(vardecl1), vl2(vardecl2);
-
-	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+	UniVars v1(vardecl1), v2(vardecl2);
 
 	v1.extend(v2);
 
@@ -128,7 +125,7 @@ void VariablesUTest::test_extend_1()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_extend_2()
+void UniVarsUTest::test_extend_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -143,9 +140,7 @@ void VariablesUTest::test_extend_2()
 		            al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE)),
 		            al(TYPED_VARIABLE_LINK, Y, CNT));
 
-	VariableList vl1(vardecl1), vl2(vardecl2);
-
-	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+	UniVars v1(vardecl1), v2(vardecl2);
 
 	v1.extend(v2);
 
@@ -159,7 +154,7 @@ void VariablesUTest::test_extend_2()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_extend_3()
+void UniVarsUTest::test_extend_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -174,9 +169,7 @@ void VariablesUTest::test_extend_3()
 			            al(TYPED_VARIABLE_LINK, X, PNT),
 			            al(TYPED_VARIABLE_LINK, Y, CNT));
 
-	VariableList vl1(vardecl1), vl2(vardecl2);
-
-	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+	UniVars v1(vardecl1), v2(vardecl2);
 
 	v1.extend(v2);
 
@@ -190,7 +183,7 @@ void VariablesUTest::test_extend_3()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_extend_4()
+void UniVarsUTest::test_extend_4()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -205,9 +198,7 @@ void VariablesUTest::test_extend_4()
 			            al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, CNT, LLT)),
 			            al(TYPED_VARIABLE_LINK, Y, NT));
 
-	VariableList vl1(vardecl1), vl2(vardecl2);
-
-	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+	UniVars v1(vardecl1), v2(vardecl2);
 
 	v1.extend(v2);
 
@@ -221,7 +212,7 @@ void VariablesUTest::test_extend_4()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_extend_5()
+void UniVarsUTest::test_extend_5()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -265,9 +256,7 @@ void VariablesUTest::test_extend_5()
 			                     an(NUMBER_NODE, "2")),
 			                  PNT)));
 
-	VariableList vl1(vardecl1), vl2(vardecl2);
-
-	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+	UniVars v1(vardecl1), v2(vardecl2);
 
 	v1.extend(v2);
 
@@ -281,7 +270,7 @@ void VariablesUTest::test_extend_5()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_extend_6()
+void UniVarsUTest::test_extend_6()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -295,9 +284,7 @@ void VariablesUTest::test_extend_6()
 			            al(TYPED_VARIABLE_LINK, X, PNT),
 			            al(TYPED_VARIABLE_LINK, G2, PNT));
 
-	VariableList vl1(vardecl1), vl2(vardecl2);
-
-	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+	UniVars v1(vardecl1), v2(vardecl2);
 
 	v1.extend(v2);
 
@@ -311,14 +298,14 @@ void VariablesUTest::test_extend_6()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_ordered_1()
+void UniVarsUTest::test_find_variables_ordered_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Inferred vardecl should be in infix order since all links are
 	// ordered, that is [X, Y].
 	Handle body = al(INHERITANCE_LINK, X, Y);
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 	HandleSeq expect{X, Y};
@@ -331,7 +318,7 @@ void VariablesUTest::test_find_variables_ordered_1()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_ordered_2()
+void UniVarsUTest::test_find_variables_ordered_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -340,7 +327,7 @@ void VariablesUTest::test_find_variables_ordered_2()
 	Handle body = al(LIST_LINK,
 	                 al(INHERITANCE_LINK, X, Y),
 	                 al(INHERITANCE_LINK, Z, W));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 	HandleSeq expect{X, Y, Z, W};
@@ -353,7 +340,7 @@ void VariablesUTest::test_find_variables_ordered_2()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_ordered_3()
+void UniVarsUTest::test_find_variables_ordered_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -362,7 +349,7 @@ void VariablesUTest::test_find_variables_ordered_3()
 	Handle body = al(LIST_LINK,
 	                 al(INHERITANCE_LINK, X, Y),
 	                 al(INHERITANCE_LINK, Y, X));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 	HandleSeq expect{X, Y};
@@ -375,7 +362,7 @@ void VariablesUTest::test_find_variables_ordered_3()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_ordered_4()
+void UniVarsUTest::test_find_variables_ordered_4()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -387,7 +374,7 @@ void VariablesUTest::test_find_variables_ordered_4()
 	                 al(QUOTE_LINK, Y),
 	                 al(INHERITANCE_LINK, X, Y),
 	                 al(SCOPE_LINK, al(INHERITANCE_LINK, Z, W)));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 	HandleSeq expect{X, Y};
@@ -400,14 +387,14 @@ void VariablesUTest::test_find_variables_ordered_4()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_unordered_1()
+void UniVarsUTest::test_find_variables_unordered_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
 	// Inferred vardecl may not follow any particular order since the
 	// body structure imposes no asymmetry.
 	Handle body = al(AND_LINK, X, Y);
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSet result = vars.varset;
 	HandleSet expect{X, Y};
@@ -420,7 +407,7 @@ void VariablesUTest::test_find_variables_unordered_1()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_unordered_2()
+void UniVarsUTest::test_find_variables_unordered_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -434,7 +421,7 @@ void VariablesUTest::test_find_variables_unordered_2()
 	Handle body = al(AND_LINK,
 	                 al(OR_LINK, X, Y),
 	                 al(OR_LINK, Z, W));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 
@@ -455,7 +442,7 @@ void VariablesUTest::test_find_variables_unordered_2()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_unordered_3()
+void UniVarsUTest::test_find_variables_unordered_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -464,7 +451,7 @@ void VariablesUTest::test_find_variables_unordered_3()
 	Handle body = al(AND_LINK,
 	                 al(OR_LINK, X, Y),
 	                 al(OR_LINK, Z, Z));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 
@@ -481,7 +468,7 @@ void VariablesUTest::test_find_variables_unordered_3()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_unordered_4()
+void UniVarsUTest::test_find_variables_unordered_4()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -490,7 +477,7 @@ void VariablesUTest::test_find_variables_unordered_4()
 	Handle body = al(AND_LINK,
 	                 al(AND_LINK, X, Y),
 	                 al(OR_LINK, Z, W));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 
@@ -508,7 +495,7 @@ void VariablesUTest::test_find_variables_unordered_4()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_unordered_5()
+void UniVarsUTest::test_find_variables_unordered_5()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -520,8 +507,8 @@ void VariablesUTest::test_find_variables_unordered_5()
 	Handle body2 = al(OR_LINK,
 	                  al(AND_LINK, Y, A),
 	                  al(AND_LINK, X, B));
-	Variables vars1;
-	Variables vars2;
+	UniVars vars1;
+	UniVars vars2;
 	vars1.find_variables(body1);
 	vars2.find_variables(body2);
 	HandleSeq varseq1 = vars1.varseq;
@@ -538,7 +525,7 @@ void VariablesUTest::test_find_variables_unordered_5()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_1()
+void UniVarsUTest::test_find_variables_mixed_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -547,7 +534,7 @@ void VariablesUTest::test_find_variables_mixed_1()
 	Handle body = al(AND_LINK,
 	                 al(INHERITANCE_LINK, X, Y),
 	                 al(INHERITANCE_LINK, Y, X));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSet result = vars.varset;
 	HandleSet expect{X, Y};
@@ -561,7 +548,7 @@ void VariablesUTest::test_find_variables_mixed_1()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_2()
+void UniVarsUTest::test_find_variables_mixed_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -571,7 +558,7 @@ void VariablesUTest::test_find_variables_mixed_2()
 	Handle body = al(AND_LINK,
 	                 al(SUBSET_LINK, X, Y),
 	                 al(INTENSIONAL_INHERITANCE_LINK, Y, X));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 	HandleSeq expect{X, Y};
@@ -584,7 +571,7 @@ void VariablesUTest::test_find_variables_mixed_2()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_3()
+void UniVarsUTest::test_find_variables_mixed_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -594,8 +581,8 @@ void VariablesUTest::test_find_variables_mixed_3()
 	Handle body1 = al(INHERITANCE_LINK, al(AND_LINK, X, Y), Y);
 	Handle body2 = al(INHERITANCE_LINK, al(AND_LINK, Y, X), X);
 
-	Variables vars1;
-	Variables vars2;
+	UniVars vars1;
+	UniVars vars2;
 	vars1.find_variables(body1);
 	vars2.find_variables(body2);
 	HandleSeq varseq1 = vars1.varseq;
@@ -612,7 +599,7 @@ void VariablesUTest::test_find_variables_mixed_3()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_4()
+void UniVarsUTest::test_find_variables_mixed_4()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -623,7 +610,7 @@ void VariablesUTest::test_find_variables_mixed_4()
 	                 al(INHERITANCE_LINK, Y, X),
 	                 al(INHERITANCE_LINK, Z, W),
 	                 al(INHERITANCE_LINK, W, Z));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq result = vars.varseq;
 	HandleSeq expect1{X, Y, Z, W};
@@ -657,7 +644,7 @@ void VariablesUTest::test_find_variables_mixed_4()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_5()
+void UniVarsUTest::test_find_variables_mixed_5()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -667,7 +654,7 @@ void VariablesUTest::test_find_variables_mixed_5()
 	                 al(INHERITANCE_LINK, X, Y),
 	                 al(INHERITANCE_LINK, Y, X),
 	                 al(INHERITANCE_LINK, A, B));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSet result = vars.varset;
 	HandleSet expect{X, Y};
@@ -681,7 +668,7 @@ void VariablesUTest::test_find_variables_mixed_5()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_6()
+void UniVarsUTest::test_find_variables_mixed_6()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -695,8 +682,8 @@ void VariablesUTest::test_find_variables_mixed_6()
 	                  al(SET_LINK, Y, X),
 	                  al(LIST_LINK, Y, X));
 
-	Variables vars1;
-	Variables vars2;
+	UniVars vars1;
+	UniVars vars2;
 	vars1.find_variables(body1);
 	vars2.find_variables(body2);
 	HandleSeq varseq1 = vars1.varseq;
@@ -713,7 +700,7 @@ void VariablesUTest::test_find_variables_mixed_6()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_7()
+void UniVarsUTest::test_find_variables_mixed_7()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -727,8 +714,8 @@ void VariablesUTest::test_find_variables_mixed_7()
 	                  al(SET_LINK, Y, X),
 	                  al(LIST_LINK, Y, X));
 
-	Variables vars1;
-	Variables vars2;
+	UniVars vars1;
+	UniVars vars2;
 	vars1.find_variables(body1);
 	vars2.find_variables(body2);
 	HandleSeq varseq1 = vars1.varseq;
@@ -745,7 +732,7 @@ void VariablesUTest::test_find_variables_mixed_7()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_8()
+void UniVarsUTest::test_find_variables_mixed_8()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -756,7 +743,7 @@ void VariablesUTest::test_find_variables_mixed_8()
 	Handle ZYX = al(LIST_LINK, Z, Y, X);
 	Handle XZY = al(LIST_LINK, X, Z, Y);
 	Handle body = al(LIST_LINK, al(SET_LINK, XYZ, ZYX), XZY);
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq result = vars.varseq;
 	HandleSeq expect{X, Y, Z};
@@ -769,7 +756,7 @@ void VariablesUTest::test_find_variables_mixed_8()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_9()
+void UniVarsUTest::test_find_variables_mixed_9()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -781,8 +768,8 @@ void VariablesUTest::test_find_variables_mixed_9()
 	Handle body2 = al(LIST_LINK,
 	                  al(SET_LINK, Y, X),
 	                  al(SET_LINK, Y, al(LIST_LINK, X)));
-	Variables vars1;
-	Variables vars2;
+	UniVars vars1;
+	UniVars vars2;
 	vars1.find_variables(body1);
 	vars2.find_variables(body2);
 	HandleSeq varseq1 = vars1.varseq;
@@ -799,7 +786,7 @@ void VariablesUTest::test_find_variables_mixed_9()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_10()
+void UniVarsUTest::test_find_variables_mixed_10()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -808,7 +795,7 @@ void VariablesUTest::test_find_variables_mixed_10()
 	                 al(VARIABLE_LIST, X, Y),
 	                 al(LOCAL_QUOTE_LINK,
 	                    al(AND_LINK, X, Y)));
-	Variables vars;
+	UniVars vars;
 	vars.find_variables(body);
 	HandleSeq varseq = vars.varseq;
 
@@ -819,7 +806,7 @@ void VariablesUTest::test_find_variables_mixed_10()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_find_variables_mixed_11()
+void UniVarsUTest::test_find_variables_mixed_11()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -831,8 +818,8 @@ void VariablesUTest::test_find_variables_mixed_11()
 	Handle body2 = al(PRESENT_LINK,
 	                  al(INHERITANCE_LINK, Y, A),
 	                  al(INHERITANCE_LINK, X, B));
-	Variables vars1;
-	Variables vars2;
+	UniVars vars1;
+	UniVars vars2;
 	vars1.find_variables(body1);
 	vars2.find_variables(body2);
 	HandleSeq varseq1 = vars1.varseq;
@@ -849,7 +836,7 @@ void VariablesUTest::test_find_variables_mixed_11()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_is_type_1()
+void UniVarsUTest::test_is_type_1()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -857,7 +844,7 @@ void VariablesUTest::test_is_type_1()
 	                    al(TYPED_VARIABLE_LINK, X, PNT),
 	                    al(TYPED_VARIABLE_LINK, Y, CNT));
 
-	Variables v1(vardecl);
+	UniVars v1(vardecl);
 
 	bool is_x = v1.is_type(X, A);
 	bool is_y = v1.is_type(Y, A);
@@ -868,7 +855,7 @@ void VariablesUTest::test_is_type_1()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_is_type_2()
+void UniVarsUTest::test_is_type_2()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -886,7 +873,7 @@ void VariablesUTest::test_is_type_2()
 	                             an(NUMBER_NODE, "2")),
 	                          CNT)));
 
-	Variables v1(vardecl);
+	UniVars v1(vardecl);
 
 	bool is_x = v1.is_type(G1, al(LIST_LINK, A, B));
 	bool is_y = v1.is_type(G2, al(LIST_LINK, A, B));
@@ -897,7 +884,7 @@ void VariablesUTest::test_is_type_2()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_is_type_3()
+void UniVarsUTest::test_is_type_3()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -910,7 +897,7 @@ void VariablesUTest::test_is_type_3()
 	                             an(NUMBER_NODE, "2")),
 	                          PNT)));
 
-	Variables v1(vardecl);
+	UniVars v1(vardecl);
 
 	bool is_x = v1.is_type(G1, al(LIST_LINK, A, B));
 	bool is_y = v1.is_type(G2, al(LIST_LINK, A, B));
@@ -921,7 +908,7 @@ void VariablesUTest::test_is_type_3()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_is_type_4()
+void UniVarsUTest::test_is_type_4()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -939,7 +926,7 @@ void VariablesUTest::test_is_type_4()
 	                             an(NUMBER_NODE, "1")),
 	                          CNT)));
 
-	Variables v1(vardecl);
+	UniVars v1(vardecl);
 
 	bool is_x = v1.is_type(G1, al(LIST_LINK, A));
 	bool is_y = v1.is_type(G2, A);
@@ -950,7 +937,7 @@ void VariablesUTest::test_is_type_4()
 	logger().info("END TEST: %s", __FUNCTION__);
 }
 
-void VariablesUTest::test_substitute_nocheck_scope()
+void UniVarsUTest::test_substitute_nocheck_scope()
 {
 	logger().info("BEGIN TEST: %s", __FUNCTION__);
 
@@ -963,7 +950,7 @@ void VariablesUTest::test_substitute_nocheck_scope()
 	// Replace Y by X, thus X in the satisfaction link above should be
 	// renamed to avoid name collision.
 	HandleMap var2val{{Y, X}};
-	Handle result = Variables(Y).substitute_nocheck(body, var2val);
+	Handle result = UniVars(Y).substitute_nocheck(body, var2val);
 	Handle expect = al(SATISFACTION_LINK,
 	                   Z,
 	                   al(PRESENT_LINK, al(INHERITANCE_LINK, Z, X)));

--- a/tests/unify/VariablesUTest.cxxtest
+++ b/tests/unify/VariablesUTest.cxxtest
@@ -1,0 +1,977 @@
+/*
+ * tests/atoms/core/VariablesUTest.cxxtest
+ *
+ * Copyright (C) 2016 OpenCog Foundation
+ * All Rights Reserved
+ * Author: Nil Geisweiller
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License v3 as
+ * published by the Free Software Foundation and including the exceptions
+ * at http://opencog.org/wiki/Licenses
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, write to:
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <opencog/atoms/core/Variables.h>
+#include <opencog/atoms/core/VariableList.h>
+#include <opencog/atomspace/AtomSpace.h>
+
+#include <cxxtest/TestSuite.h>
+
+using namespace opencog;
+
+#define al _as.add_link
+#define an _as.add_node
+
+class VariablesUTest : public CxxTest::TestSuite
+{
+private:
+	Handle A, B, W, X, Y, Z, G1, G2, NT, PNT, CNT, NTI, DPTCI, LLT, LTI;
+
+	AtomSpace _as;
+
+public:
+	VariablesUTest()
+	{
+		logger().set_level(Logger::DEBUG);
+		logger().set_timestamp_flag(false);
+		logger().set_print_to_stdout_flag(true);
+
+		A = an(CONCEPT_NODE, "A");
+		B = an(CONCEPT_NODE, "B");
+		X = an(VARIABLE_NODE, "$X");
+		Y = an(VARIABLE_NODE, "$Y");
+		Z = an(VARIABLE_NODE, "$Z");
+		W = an(VARIABLE_NODE, "$W");
+		G1 = an(GLOB_NODE, "$G1");
+		G2 = an(GLOB_NODE, "$G2");
+		NT = an(TYPE_NODE, "Node");
+		PNT = an(TYPE_NODE, "PredicateNode");
+		CNT = an(TYPE_NODE, "ConceptNode");
+		NTI = an(TYPE_INH_NODE, "Node");
+		DPTCI = an(TYPE_CO_INH_NODE, "DefinedPredicateNode");
+		LLT = an(TYPE_NODE, "ListLink");
+		LTI = an(TYPE_INH_NODE, "Link");
+	}
+
+	void test_extend_1();
+	void test_extend_2();
+	void test_extend_3();
+	void test_extend_4();
+	void test_extend_5();
+	void test_extend_6();
+
+	void test_find_variables_ordered_1();
+	void test_find_variables_ordered_2();
+	void test_find_variables_ordered_3();
+	void test_find_variables_ordered_4();
+	void test_find_variables_unordered_1();
+	void test_find_variables_unordered_2();
+	void test_find_variables_unordered_3();
+	void test_find_variables_unordered_4();
+	void test_find_variables_unordered_5();
+	void test_find_variables_mixed_1();
+	void test_find_variables_mixed_2();
+	void test_find_variables_mixed_3();
+	void test_find_variables_mixed_4();
+	void test_find_variables_mixed_5();
+	void test_find_variables_mixed_6();
+	void test_find_variables_mixed_7();
+	void test_find_variables_mixed_8();
+	void test_find_variables_mixed_9();
+	void test_find_variables_mixed_10();
+	void test_find_variables_mixed_11();
+
+	void test_is_type_1();
+	void test_is_type_2();
+	void test_is_type_3();
+	void test_is_type_4();
+
+	void test_substitute_nocheck_scope();
+};
+
+void VariablesUTest::test_extend_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+		vardecl1 = X,
+		vardecl2 = al(VARIABLE_LIST,
+		              al(TYPED_VARIABLE_LINK, X, PNT),
+		              al(TYPED_VARIABLE_LINK, Y, CNT)),
+		expect = al(VARIABLE_LIST,
+		            al(TYPED_VARIABLE_LINK, X, PNT),
+		            al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_extend_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+		vardecl1 = al(VARIABLE_LIST,
+		              al(TYPED_VARIABLE_LINK, X, NT),
+		              al(TYPED_VARIABLE_LINK, Y, CNT)),
+		vardecl2 = al(VARIABLE_LIST,
+		              al(TYPED_VARIABLE_LINK, X, PNT),
+		              al(TYPED_VARIABLE_LINK, Y, al(TYPE_CHOICE, PNT, CNT))),
+		expect = al(VARIABLE_LIST,
+		            al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE)),
+		            al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_extend_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+			vardecl1 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, PNT),
+			              al(TYPED_VARIABLE_LINK, Y, CNT)),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, NTI),
+			              al(TYPED_VARIABLE_LINK, Y, al(TYPE_CHOICE, PNT, CNT))),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, X, PNT),
+			            al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_extend_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle
+			vardecl1 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, LLT, NTI)),
+			              al(TYPED_VARIABLE_LINK, Y, NT)),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, LTI, CNT)),
+			              al(TYPED_VARIABLE_LINK, Y, DPTCI)),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, X, al(TYPE_CHOICE, CNT, LLT)),
+			            al(TYPED_VARIABLE_LINK, Y, NT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_extend_5()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl1 = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          NTI)),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          PNT))),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, G1,
+			                 al(TYPE_SET_LINK,
+			                    al(INTERVAL_LINK,
+			                       an(NUMBER_NODE, "1"),
+			                       an(NUMBER_NODE, "-1")),
+			                    PNT)),
+			              al(TYPED_VARIABLE_LINK, G2,
+			                 al(TYPE_SET_LINK,
+			                    al(INTERVAL_LINK,
+			                       an(NUMBER_NODE, "1"),
+			                       an(NUMBER_NODE, "3")),
+			                    PNT))),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, G1,
+			               al(TYPE_SET_LINK,
+			                  al(INTERVAL_LINK,
+			                     an(NUMBER_NODE, "1"),
+			                     an(NUMBER_NODE, "2")),
+			                  PNT)),
+			            al(TYPED_VARIABLE_LINK, G2,
+			               al(TYPE_SET_LINK,
+			                  al(INTERVAL_LINK,
+			                     an(NUMBER_NODE, "1"),
+			                     an(NUMBER_NODE, "2")),
+			                  PNT)));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_extend_6()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl1 = al(VARIABLE_LIST,
+	                     al(TYPED_VARIABLE_LINK, X, NTI),
+	                     al(TYPED_VARIABLE_LINK, G2, PNT)),
+			vardecl2 = al(VARIABLE_LIST,
+			              al(TYPED_VARIABLE_LINK, X, PNT),
+			              al(TYPED_VARIABLE_LINK, G2, PNT)),
+			expect = al(VARIABLE_LIST,
+			            al(TYPED_VARIABLE_LINK, X, PNT),
+			            al(TYPED_VARIABLE_LINK, G2, PNT));
+
+	VariableList vl1(vardecl1), vl2(vardecl2);
+
+	Variables v1(vl1.get_variables()), v2(vl2.get_variables());
+
+	v1.extend(v2);
+
+	Handle result = _as.add_atom(v1.get_vardecl());
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_ordered_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl should be in infix order since all links are
+	// ordered, that is [X, Y].
+	Handle body = al(INHERITANCE_LINK, X, Y);
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+	HandleSeq expect{X, Y};
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_ordered_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl should be in infix order since all links are
+	// ordered, that is [X, Y, Z, W].
+	Handle body = al(LIST_LINK,
+	                 al(INHERITANCE_LINK, X, Y),
+	                 al(INHERITANCE_LINK, Z, W));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+	HandleSeq expect{X, Y, Z, W};
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_ordered_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl should be in infix order since all links are
+	// ordered, that is [X, Y], as it eliminate redundant variables.
+	Handle body = al(LIST_LINK,
+	                 al(INHERITANCE_LINK, X, Y),
+	                 al(INHERITANCE_LINK, Y, X));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+	HandleSeq expect{X, Y};
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_ordered_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Simple ordered body with quoted and scoped variables (thus that
+	// should be ignored). Result should be [X, Y] as the first
+	// occurence of Y is quoted, and other variables like Z and W are
+	// scoped.
+	Handle body = al(LIST_LINK,
+	                 al(QUOTE_LINK, Y),
+	                 al(INHERITANCE_LINK, X, Y),
+	                 al(SCOPE_LINK, al(INHERITANCE_LINK, Z, W)));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+	HandleSeq expect{X, Y};
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_unordered_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl may not follow any particular order since the
+	// body structure imposes no asymmetry.
+	Handle body = al(AND_LINK, X, Y);
+	Variables vars;
+	vars.find_variables(body);
+	HandleSet result = vars.varset;
+	HandleSet expect{X, Y};
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_unordered_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl can be one of the possibilities
+	//
+	// 1. sorted({X, Y}) + sorted({Z, W})
+	// 2. sorted({Z, W}) + sorted({X, Y})
+	//
+	// X, Y and Z, W can be interleaved because it is would not be
+	// semantically equivalent.
+	Handle body = al(AND_LINK,
+	                 al(OR_LINK, X, Y),
+	                 al(OR_LINK, Z, W));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+
+	HandleSet XY{X, Y}, ZW{Z, W};
+	HandleSeq expect1;
+	expect1.insert(expect1.end(), XY.begin(), XY.end());
+	expect1.insert(expect1.end(), ZW.begin(), ZW.end());
+	HandleSeq expect2;
+	expect2.insert(expect2.end(), ZW.begin(), ZW.end());
+	expect2.insert(expect2.end(), XY.begin(), XY.end());
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect1 = " << oc_to_string(expect1);
+	logger().debug() << "expect2 = " << oc_to_string(expect2);
+
+	TS_ASSERT(varseq == expect1 or varseq == expect2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_unordered_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl should have Z come last because it occurs more
+	// often than X and Y.
+	Handle body = al(AND_LINK,
+	                 al(OR_LINK, X, Y),
+	                 al(OR_LINK, Z, Z));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+
+	HandleSet XY = HandleSet{X, Y};
+	HandleSeq expect;
+	expect.insert(expect.end(), XY.begin(), XY.end());
+	expect.push_back(Z);
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_unordered_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl should be sorted({X, Y}) + sorted({Z, W})
+	// because AndLink type is less than OrLink type.
+	Handle body = al(AND_LINK,
+	                 al(AND_LINK, X, Y),
+	                 al(OR_LINK, Z, W));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+
+	HandleSet XY = HandleSet{X, Y};
+	HandleSet ZW = HandleSet{Z, W};
+	HandleSeq expect;
+	expect.insert(expect.end(), XY.begin(), XY.end());
+	expect.insert(expect.end(), ZW.begin(), ZW.end());
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_unordered_5()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl of body1 should be the reverse of inferred
+	// vardecl of body2.
+	Handle body1 = al(OR_LINK,
+	                  al(AND_LINK, X, A),
+	                  al(AND_LINK, Y, B));
+	Handle body2 = al(OR_LINK,
+	                  al(AND_LINK, Y, A),
+	                  al(AND_LINK, X, B));
+	Variables vars1;
+	Variables vars2;
+	vars1.find_variables(body1);
+	vars2.find_variables(body2);
+	HandleSeq varseq1 = vars1.varseq;
+	HandleSeq varseq2 = vars2.varseq;
+
+	logger().debug() << "varseq1 = " << oc_to_string(varseq1);
+	logger().debug() << "varseq2 = " << oc_to_string(varseq2);
+
+	// Reverse varseq2 to test it if it equal to varseq1
+	std::reverse(varseq2.begin(), varseq2.end());
+
+	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl may not follow any particular order since the
+	// body structure imposes no asymmetry.
+	Handle body = al(AND_LINK,
+	                 al(INHERITANCE_LINK, X, Y),
+	                 al(INHERITANCE_LINK, Y, X));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSet result = vars.varset;
+	HandleSet expect{X, Y};
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	// Just make sure the vardecl has X and Y, regardless of the order
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl should place X before Y because the
+	// ExtensionalSimilarityLink type is ordered before
+	// IntensionalSimilarityLink type.
+	Handle body = al(AND_LINK,
+	                 al(SUBSET_LINK, X, Y),
+	                 al(INTENSIONAL_INHERITANCE_LINK, Y, X));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+	HandleSeq expect{X, Y};
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(varseq, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Make sure the variable declarations of body1 and body2 are
+	// the reverses of each other, that is if one is [X, Y], then
+	// the other is [Y, X].
+	Handle body1 = al(INHERITANCE_LINK, al(AND_LINK, X, Y), Y);
+	Handle body2 = al(INHERITANCE_LINK, al(AND_LINK, Y, X), X);
+
+	Variables vars1;
+	Variables vars2;
+	vars1.find_variables(body1);
+	vars2.find_variables(body2);
+	HandleSeq varseq1 = vars1.varseq;
+	HandleSeq varseq2 = vars2.varseq;
+
+	logger().debug() << "varseq1 = " << oc_to_string(varseq1);
+	logger().debug() << "varseq2 = " << oc_to_string(varseq2);
+
+	// Reverse varseq2 to test it if it equal to varseq1
+	std::reverse(varseq2.begin(), varseq2.end());
+
+	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl can be any combination where {X, Y} and {Z, W}
+	// do not interleave.
+	Handle body = al(AND_LINK,
+	                 al(INHERITANCE_LINK, X, Y),
+	                 al(INHERITANCE_LINK, Y, X),
+	                 al(INHERITANCE_LINK, Z, W),
+	                 al(INHERITANCE_LINK, W, Z));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq result = vars.varseq;
+	HandleSeq expect1{X, Y, Z, W};
+	HandleSeq expect2{Y, X, Z, W};
+	HandleSeq expect3{X, Y, W, Z};
+	HandleSeq expect4{Y, X, W, Z};
+	HandleSeq expect5{Z, W, X, Y};
+	HandleSeq expect6{Z, W, Y, X};
+	HandleSeq expect7{W, Z, X, Y};
+	HandleSeq expect8{W, Z, Y, X};
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect1 = " << oc_to_string(expect1);
+	logger().debug() << "expect2 = " << oc_to_string(expect2);
+	logger().debug() << "expect3 = " << oc_to_string(expect3);
+	logger().debug() << "expect4 = " << oc_to_string(expect4);
+	logger().debug() << "expect5 = " << oc_to_string(expect5);
+	logger().debug() << "expect6 = " << oc_to_string(expect6);
+	logger().debug() << "expect7 = " << oc_to_string(expect7);
+	logger().debug() << "expect8 = " << oc_to_string(expect8);
+
+	TS_ASSERT(result == expect1 or
+	          result == expect2 or
+	          result == expect3 or
+	          result == expect4 or
+	          result == expect5 or
+	          result == expect6 or
+	          result == expect7 or
+	          result == expect8);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_5()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Like test_find_variables_mixed_1 but incorporates non variable
+	// nodes to cover some, otherwise non covered, code.
+	Handle body = al(AND_LINK,
+	                 al(INHERITANCE_LINK, X, Y),
+	                 al(INHERITANCE_LINK, Y, X),
+	                 al(INHERITANCE_LINK, A, B));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSet result = vars.varset;
+	HandleSet expect{X, Y};
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	// Just make sure the vardecl has X and Y, regardless of the order
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_6()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Make sure the variable declarations of body1 and body2 are
+	// the reverses of each other, that is if one is [X, Y], then
+	// the other is [Y, X].
+	Handle body1 = al(LIST_LINK,
+	                  al(SET_LINK, X, Y),
+	                  al(LIST_LINK, X, Y));
+	Handle body2 = al(LIST_LINK,
+	                  al(SET_LINK, Y, X),
+	                  al(LIST_LINK, Y, X));
+
+	Variables vars1;
+	Variables vars2;
+	vars1.find_variables(body1);
+	vars2.find_variables(body2);
+	HandleSeq varseq1 = vars1.varseq;
+	HandleSeq varseq2 = vars2.varseq;
+
+	logger().debug() << "varseq1 = " << oc_to_string(varseq1);
+	logger().debug() << "varseq2 = " << oc_to_string(varseq2);
+
+	// Reverse varseq2 to test it if it equal to varseq1
+	std::reverse(varseq2.begin(), varseq2.end());
+
+	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_7()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Make sure the variable declarations of body1 and body2 are
+	// the reverses of each other, that is if one is [X, Y], then
+	// the other is [Y, X].
+	Handle body1 = al(SET_LINK,
+	                  al(SET_LINK, X, Y),
+	                  al(LIST_LINK, X, Y));
+	Handle body2 = al(SET_LINK,
+	                  al(SET_LINK, Y, X),
+	                  al(LIST_LINK, Y, X));
+
+	Variables vars1;
+	Variables vars2;
+	vars1.find_variables(body1);
+	vars2.find_variables(body2);
+	HandleSeq varseq1 = vars1.varseq;
+	HandleSeq varseq2 = vars2.varseq;
+
+	logger().debug() << "varseq1 = " << oc_to_string(varseq1);
+	logger().debug() << "varseq2 = " << oc_to_string(varseq2);
+
+	// Reverse varseq2 to test it if it equal to varseq1
+	std::reverse(varseq2.begin(), varseq2.end());
+
+	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_8()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// The order should be XYZ, because Z appears after X in the
+	// ordered link XZY, which makes XYZ before ordered before ZYX in
+	// the SetLink.
+	Handle XYZ = al(LIST_LINK, X, Y, Z);
+	Handle ZYX = al(LIST_LINK, Z, Y, X);
+	Handle XZY = al(LIST_LINK, X, Z, Y);
+	Handle body = al(LIST_LINK, al(SET_LINK, XYZ, ZYX), XZY);
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq result = vars.varseq;
+	HandleSeq expect{X, Y, Z};
+
+	logger().debug() << "result = " << oc_to_string(result);
+	logger().debug() << "expect = " << oc_to_string(expect);
+
+	TS_ASSERT_EQUALS(result, expect);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_9()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// The vardecl order of body1 should be the reverse of the vardecl
+	// order of body2.
+	Handle body1 = al(LIST_LINK,
+	                 al(SET_LINK, X, Y),
+	                 al(SET_LINK, X, al(LIST_LINK, Y)));
+	Handle body2 = al(LIST_LINK,
+	                  al(SET_LINK, Y, X),
+	                  al(SET_LINK, Y, al(LIST_LINK, X)));
+	Variables vars1;
+	Variables vars2;
+	vars1.find_variables(body1);
+	vars2.find_variables(body2);
+	HandleSeq varseq1 = vars1.varseq;
+	HandleSeq varseq2 = vars2.varseq;
+
+	logger().debug() << "varseq1 = " << oc_to_string(varseq1);
+	logger().debug() << "varseq2 = " << oc_to_string(varseq2);
+
+	// Reverse varseq2 to test it if it equal to varseq1
+	std::reverse(varseq2.begin(), varseq2.end());
+
+	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_10()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// The vardecl should be empty because no variable are free.
+	Handle body = al(LAMBDA_LINK,
+	                 al(VARIABLE_LIST, X, Y),
+	                 al(LOCAL_QUOTE_LINK,
+	                    al(AND_LINK, X, Y)));
+	Variables vars;
+	vars.find_variables(body);
+	HandleSeq varseq = vars.varseq;
+
+	logger().debug() << "varseq = " << oc_to_string(varseq);
+
+	TS_ASSERT_EQUALS(varseq, HandleSeq());
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_find_variables_mixed_11()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Inferred vardecl of body1 should be the reverse of vardecl of
+	// body2 because swapping names makes them equivalent.
+	Handle body1 = al(PRESENT_LINK,
+	                  al(INHERITANCE_LINK, X, A),
+	                  al(INHERITANCE_LINK, Y, B));
+	Handle body2 = al(PRESENT_LINK,
+	                  al(INHERITANCE_LINK, Y, A),
+	                  al(INHERITANCE_LINK, X, B));
+	Variables vars1;
+	Variables vars2;
+	vars1.find_variables(body1);
+	vars2.find_variables(body2);
+	HandleSeq varseq1 = vars1.varseq;
+	HandleSeq varseq2 = vars2.varseq;
+
+	logger().debug() << "varseq1 = " << oc_to_string(varseq1);
+	logger().debug() << "varseq2 = " << oc_to_string(varseq2);
+
+	// Reverse varseq2 to test it if it equal to varseq1
+	std::reverse(varseq2.begin(), varseq2.end());
+
+	TS_ASSERT_EQUALS(varseq1, varseq2);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_is_type_1()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, X, PNT),
+	                    al(TYPED_VARIABLE_LINK, Y, CNT));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(X, A);
+	bool is_y = v1.is_type(Y, A);
+
+	TS_ASSERT(not is_x);
+	TS_ASSERT(is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_is_type_2()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "1")),
+	                          CNT)),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          CNT)));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(G1, al(LIST_LINK, A, B));
+	bool is_y = v1.is_type(G2, al(LIST_LINK, A, B));
+
+	TS_ASSERT(not is_x);
+	TS_ASSERT(is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_is_type_3()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1, CNT),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "0"),
+	                             an(NUMBER_NODE, "2")),
+	                          PNT)));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(G1, al(LIST_LINK, A, B));
+	bool is_y = v1.is_type(G2, al(LIST_LINK, A, B));
+
+	TS_ASSERT(is_x);
+	TS_ASSERT(not is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_is_type_4()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	Handle vardecl = al(VARIABLE_LIST,
+	                    al(TYPED_VARIABLE_LINK, G1,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "1"),
+	                             an(NUMBER_NODE, "1")),
+	                          CNT)),
+	                    al(TYPED_VARIABLE_LINK, G2,
+	                       al(TYPE_SET_LINK,
+	                          al(INTERVAL_LINK,
+	                             an(NUMBER_NODE, "1"),
+	                             an(NUMBER_NODE, "1")),
+	                          CNT)));
+
+	Variables v1(vardecl);
+
+	bool is_x = v1.is_type(G1, al(LIST_LINK, A));
+	bool is_y = v1.is_type(G2, A);
+
+	TS_ASSERT(is_x);
+	TS_ASSERT(is_y);
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}
+
+void VariablesUTest::test_substitute_nocheck_scope()
+{
+	logger().info("BEGIN TEST: %s", __FUNCTION__);
+
+	// Body with only one variable declared X, thus Y can be
+	// substituted but not X.
+	Handle body = al(SATISFACTION_LINK,
+	                 X,
+	                 al(PRESENT_LINK, al(INHERITANCE_LINK, X, Y)));
+
+	// Replace Y by X, thus X in the satisfaction link above should be
+	// renamed to avoid name collision.
+	HandleMap var2val{{Y, X}};
+	Handle result = Variables(Y).substitute_nocheck(body, var2val);
+	Handle expect = al(SATISFACTION_LINK,
+	                   Z,
+	                   al(PRESENT_LINK, al(INHERITANCE_LINK, Z, X)));
+
+	logger().debug() << "expect = " << oc_to_string(expect);
+	logger().debug() << "result = " << oc_to_string(result);
+
+	TS_ASSERT(content_eq(result, expect));
+
+	logger().info("END TEST: %s", __FUNCTION__);
+}


### PR DESCRIPTION
I'm trying to drastically simplify `struct Variables` in the AtomSpace,
and found that the primary user of the non-orthogonal stuff is the
Unifier.  Thus, the simplest solution seems to be to create a Unifier-specific
variable unifier, which is what this pull req does.

The need to simplify `struct Variables` is driven by opencog/atomspace#2644

This seems to pass unit tests. I'm guessing that in making this copy, I pulled
over a lot of other cruft, which can be removed at leisure... One possibility is to
have `UniVars` inherit from `Variables`, instead of being just a copy of it...