### PR TITLE
Expose ure logger to Python

### DIFF
--- a/opencog/cython/opencog/logger.pyx
+++ b/opencog/cython/opencog/logger.pyx
@@ -1,0 +1,7 @@
+from ure cimport ure_logger as c_ure_logger
+from opencog.logger cimport wrap_clogger, cLogger
+
+def ure_logger():
+    cdef cLogger cl = c_ure_logger()
+    z= wrap_clogger(&cl)
+    return z

--- a/opencog/cython/opencog/logger.pyx
+++ b/opencog/cython/opencog/logger.pyx
@@ -2,6 +2,5 @@ from ure cimport ure_logger as c_ure_logger
 from opencog.logger cimport wrap_clogger, cLogger
 
 def ure_logger():
-    cdef cLogger cl = c_ure_logger()
-    z= wrap_clogger(&cl)
+    z = wrap_clogger(&c_ure_logger())
     return z

--- a/opencog/cython/opencog/ure.pxd
+++ b/opencog/cython/opencog/ure.pxd
@@ -1,6 +1,7 @@
 from libcpp.set cimport set
 from libcpp.vector cimport vector
 from opencog.atomspace cimport cHandle, cAtomSpace
+from opencog.logger cimport cLogger
 
 
 cdef extern from "opencog/ure/forwardchainer/ForwardChainer.h" namespace "opencog":
@@ -69,3 +70,7 @@ cdef extern from "opencog/ure/backwardchainer/BackwardChainer.h" namespace "open
 
         void do_chain() except +
         cHandle get_results() const
+
+
+cdef extern from "opencog/ure/URELogger.h" namespace "opencog":
+    cdef cLogger& ure_logger()

--- a/opencog/cython/opencog/ure.pyx
+++ b/opencog/cython/opencog/ure.pyx
@@ -7,3 +7,4 @@
 
 include "forwardchainer.pyx"
 include "backwardchainer.pyx"
+include "logger.pyx"


### PR DESCRIPTION
Add `opencog.ure.ure_logger`. Usage is as follows:

```python
from opencog.ure import ure_logger
ure_logger().set_level("debug")
...
```

Fix issue https://github.com/opencog/ure/issues/86