### PR TITLE
Explicitly clear the COW flag on AtomSpaces

### DIFF
--- a/opencog/ure/backwardchainer/BIT.cc
+++ b/opencog/ure/backwardchainer/BIT.cc
@@ -800,7 +800,10 @@ BIT::BIT(AtomSpace& as,
          const BITNodeFitness& fitness)
 	: bit_as(&as), // child atomspace of as
 	  _as(&as), _init_target(target), _init_vardecl(vardecl),
-	  _init_fitness(fitness) {}
+	  _init_fitness(fitness)
+{
+	bit_as.clear_copy_on_write();
+}
 
 BIT::~BIT() {}
 

--- a/opencog/ure/backwardchainer/BackwardChainer.cc
+++ b/opencog/ure/backwardchainer/BackwardChainer.cc
@@ -266,6 +266,7 @@ void BackwardChainer::fulfill_fcs(const Handle& fcs)
 	// Temporary atomspace to not pollute _as with intermediary
 	// results
 	AtomSpacePtr tmp_as(createAtomSpace(&_kb_as));
+	tmp_as->clear_copy_on_write(); // tmp_as should be write-through.
 
 	// Run the FCS and add the results, if any, in _as.
 	//

--- a/opencog/ure/backwardchainer/ControlPolicy.cc
+++ b/opencog/ure/backwardchainer/ControlPolicy.cc
@@ -59,6 +59,7 @@ ControlPolicy::ControlPolicy(const UREConfig& ure_config, const BIT& bit,
 	// Fetches expansion control rules from _control_as
 	if (_control_as) {
 		_query_as = createAtomSpace(_control_as);
+		_query_as->clear_copy_on_write(); // _as should be write-through.
 		for (const Handle& rule_alias : rules.aliases()) {
 			HandleSet exp_ctrl_rules = fetch_expansion_control_rules(rule_alias);
 			_expansion_control_rules[rule_alias] = exp_ctrl_rules;

--- a/opencog/ure/forwardchainer/ForwardChainer.cc
+++ b/opencog/ure/forwardchainer/ForwardChainer.cc
@@ -649,6 +649,7 @@ HandleSet ForwardChainer::apply_rule(const Rule& rule)
 	{
 		AtomSpace& ref_as(_search_focus_set ? *_focus_set_as.get() : _kb_as);
 		AtomSpacePtr derived_rule_as(createAtomSpace(&ref_as));
+		derived_rule_as->clear_copy_on_write(); // _as should be write-through.
 		Handle rhcpy = derived_rule_as->add_atom(rule.get_rule());
 
 		// Make Sure that all constant clauses appear in the AtomSpace


### PR DESCRIPTION
I'd like to change the default AtomSpace behavior to be copy-on-write.
However, the chainer design seems to expect overlay atomspaces to
be write-through. So make them explicitly write-through.